### PR TITLE
Two new exercises: implementing nondeterminism with sequences and with continuations.

### DIFF
--- a/exercises/nondet_monad_cont/AUTHOR
+++ b/exercises/nondet_monad_cont/AUTHOR
@@ -1,0 +1,1 @@
+François Pottier

--- a/exercises/nondet_monad_cont/Makefile
+++ b/exercises/nondet_monad_cont/Makefile
@@ -1,0 +1,2 @@
+LIB   := $(shell cd ../lib && pwd)
+include $(LIB)/Makefile

--- a/exercises/nondet_monad_cont/NOTES
+++ b/exercises/nondet_monad_cont/NOTES
@@ -1,0 +1,20 @@
+400 lines of introduction in descr.md,
+leading up to a Question 1
+whose solution fits in 5 lines of code.
+This is a bit frustrating,
+but I see no way of improving this situation.
+
+The analogy between
+  failure continuation / Nil
+  success continuation / Cons
+clearly shows that there is a Church (or Scott?) encoding at play,
+but I am not sure of the details.
+A rough intuition is that the continuation-based implementation
+is the Church encoding of the lazy-sequence-based implementation.
+
+When I write that a `compute` function can invoke its success continuation
+several times, this is potentially misleading: a student might think that it
+is OK to *directly* call the success continuation several times. In reality,
+the success continuation is *directly* called at most once, and to this call,
+we pass a failure continuation which itself has the ability of calling the
+success continuation again.

--- a/exercises/nondet_monad_cont/TODO
+++ b/exercises/nondet_monad_cont/TODO
@@ -1,0 +1,7 @@
+-- about this exercise ---------------------------------------------------------
+
+* Copy every change from nondet_monad_seq to nondet_monad_cont.
+
+-- ocaml questions -------------------------------------------------------------
+
+-- learn-ocaml questions -------------------------------------------------------

--- a/exercises/nondet_monad_cont/attic.ml
+++ b/exercises/nondet_monad_cont/attic.ml
@@ -1,0 +1,22 @@
+(* -------------------------------------------------------------------------- *)
+
+(* Comparing and printing sequences. *)
+
+module SeqExtra = struct
+
+  let equal_upto depth xs ys =
+    Seq.equal (=) (Seq.take depth xs) (Seq.take depth ys)
+
+  let print_upto print_element depth xs =
+    let rec contents depth xs =
+      match depth, xs() with
+      | _, Seq.Nil ->
+          []
+      | 0, Seq.Cons _ ->
+          [ utf8string "..." ]
+      | _, Seq.Cons (x, xs) ->
+          print_element x :: contents (depth - 1) xs
+    in
+    group (semis (contents depth xs))
+
+end

--- a/exercises/nondet_monad_cont/descr.md
+++ b/exercises/nondet_monad_cont/descr.md
@@ -49,7 +49,7 @@ It is in fact possible to construct computations that produce an
 infinite number of results!
 
 Thus, a useful way to think of a computation is as **a sequence of
-results**, that is, a sequence of results.
+results**.
 
 Because of this remark, one might be tempted to define the type `'a
 m` as a synonym for `'a Seq.t`, the type of sequences of values of

--- a/exercises/nondet_monad_cont/descr.md
+++ b/exercises/nondet_monad_cont/descr.md
@@ -1,0 +1,521 @@
+# Implementing Nondeterminism with Continuations
+
+In this exercise, we build an implementation of the nondeterminism
+monad. This monad admits several possible implementations; the one
+that we choose here is a continuation-based implementation where a
+computation receives two continuations, a *success continuation*
+and a *failure continuation*, which it invokes to indicate the
+presence or absence of more results.
+
+## The Nondeterminism Monad
+
+When searching for the solution of a problem, one must typically
+explore multiple choices. If a series of choices lead to a failure
+(a dead end), then one must backtrack and explore another avenue.
+
+There are a number of ways in which nondeterminism and backtracking
+can be implemented. Regardless of which implementation mechanism is
+chosen, it is desirable to hide it behind an abstraction barrier and
+present the end user with **a simple API for constructing an executing
+nondeterministic computations**.
+
+This API is known as the **nondeterminism monad**. It offers the
+following key elements:
+
+* A type `'a m`, the type of computations that yield results of type
+ `'a`.
+
+* A number of constructor functions for constructing computations,
+  such as `fail: 'a m`, which represents failure, and `choose: 'a m
+  -> 'a m -> 'a m`, which expresses a nondeterministic choice
+  between two computations.
+
+* A single observation function, `sols: 'a m -> 'a Seq.t`, which
+  converts a computation to a sequence of results, thereby allowing
+  the user to execute this computation and observe its results. The
+  name `sols` stands for `solutions`.
+
+A monad can be thought of as a **mini-programming language** where
+computations are first-class citizens: we have a type of
+computations, ways of building computations, and a way of executing
+computations.
+
+A computation in the nondeterminism monad can produce zero, one, or
+more results. Indeed, a computation that fails produces zero
+results. A computation that succeeds normally produces one result.
+A computation that uses `choose` can produce more than one result.
+It is in fact possible to construct computations that produce an
+infinite number of results!
+
+Thus, a useful way to think of a computation is as **a sequence of
+results**, that is, a sequence of results.
+
+Because of this remark, one might be tempted to define the type `'a
+m` as a synonym for `'a Seq.t`, the type of sequences of values of
+type `'a`. However, although it is possible to represent a
+computation internally as a sequence (and we will do so in this
+exercise), this is not necessarily the best implementation
+technique. Thus, we prefer to make the API more flexible by viewing
+`'a m` as an abstract type and by offering an observation function,
+`sols`, which converts a computation to a sequence.
+
+## The Nondeterminism Monad's API
+
+The signature, or API, of the nondeterminism monad is as follows:
+
+```
+  (* Type. *)
+  type 'a m
+
+  (* Constructor functions. *)
+  val return: 'a -> 'a m
+  val (>>=): 'a m -> ('a -> 'b m) -> 'b m
+  val fail: 'a m
+  val choose: 'a m -> 'a m -> 'a m
+  val delay: (unit -> 'a m) -> 'a m
+  val at_most_once: 'a m -> 'a m
+  val interleave: 'a m -> 'a m -> 'a m
+  val (>>-): 'a m -> ('a -> 'b m) -> 'b m
+
+  (* Observation function. *)
+  val sols: 'a m -> 'a Seq.t
+```
+
+As explained above, a value of type `'a m` is **a description of a
+computation**, which, once executed, produces a sequence of results
+of type `'a`.
+
+To execute a computation `m`, one must first convert it to a
+sequence of type `'a Seq.t`, whose elements can then be demanded,
+one by one. (More information on the module `Seq` is given below.)
+This conversion is performed by the observation function `sols`.
+
+The call `sols m` typically terminates in constant time; the actual
+computation described by `m` takes place only when the elements of
+the sequence `sols m` are demanded, and only insofar as necessary to
+produce the elements that are demanded. For instance, applying
+`Seq.head` to the sequence `sols m` forces the computation to
+proceed up to the point where it is able to produce its first
+result.
+
+The constructor functions `return` and `(>>=)` exist in all monads.
+(They are also known as `return` and `bind`.) `return` constructs a
+trivial computation, which does nothing except return a value,
+whereas `(>>=)` constructs the sequential composition of two
+computations. Together, they allow constructing the sequential
+composition of an arbitrary number of computations.
+
+* The computation `return v` succeeds exactly once with the value
+  `v`. In other words, the sequence of values that it produces is
+  the singleton sequence composed of just `v`.
+
+* The computation `m1 >>= m2` is the sequential composition of the
+  computations `m1` and `m2`. This composition operator is
+  asymmetric: whereas its first argument `m1` is a computation of
+  type `'a m`, its second argument `m2` is a function of type `a ->
+  'b m`. Every value `x` produced by `m1` is passed to `m2`,
+  yielding a computation `m2 x`. The sequence of values produced by
+  `m1 >>= m2` is the concatenation of the sequences of values
+  produced by the computations `m2 x`, where `x` ranges over the
+  values produced by `m1`.
+
+The constructor functions `fail` and `choose` are specific of the
+nondeterminism monad. `fail` can be thought of as a 0-ary
+disjunction, whereas `choose` is a binary disjunction. Together,
+they allow constructing the disjunction of an arbitrary number of
+computations.
+
+* The computation `fail` returns no result. In other words, it
+  produces an empty sequence of values.
+
+* The sequence of values produced by `choose m1 m2` is the
+  concatenation of the sequences of values produced by `m1`
+  and by `m2`.
+
+The constructor function `delay` is used to delay the construction
+of a computation until the moment where this computation must be
+executed. Indeed, a difficulty that arises in a strict programming
+language, such as OCaml, is that the arguments passed to constructor
+functions, such as `return` and `choose`, are evaluated immediately,
+at construction time. For instance, when one writes `choose e1 e2`,
+both of the OCaml expressions `e1` and `e2` are evaluated before
+`choose` is invoked. If the evaluation of `e2` performs nontrivial
+work, then this work arguably takes place too early: indeed, there
+should be no need to evaluate `e2` until all of the values produced
+by `e1` have been demanded. To remedy this, one may write `choose e1
+(delay (fun () -> e2))`. There, the expression `e2` is placed in the
+body of an anonymous function, so `e2` is not evaluated immediately.
+This anonymous function, whose type is `unit -> 'a m`,
+is converted by `delay` to a computation of type `'a m`.
+This conversion requires no serious work;
+it is performed in constant time.
+An intuitive reason why this is possible is that the type `'a m`
+represents a *suspended* computation already,
+so the type `unit -> 'a m` represents a *suspended suspended*
+computation, which is essentially the same thing; these types
+are interconvertible at no cost.
+
+The computations `e` and `delay (fun () -> e)` produce the same
+sequence of results. The only difference between them is the time at
+which the evaluation of `e` takes place: either immediately, or only
+when the first result is demanded.
+
+It is worth noting that in a lazy language, such as Haskell, there
+is no need for `delay`. In such a language, when one writes `choose
+e1 e2`, the expressions `e1` and `e2` are *not* evaluated
+immediately: they are evaluated only when their value is demanded.
+Thus, the fact that `e2` need not be evaluated until all of the
+values produced by `e1` have been demanded goes without saying. The
+fact that there is no need for explicit uses of `delay` is arguably
+a strength of lazy languages. At the same time, the fact that it is
+not obvious where laziness plays a crucial role is arguably a
+weakness of lazy languages. In OCaml, in contrast, the explicit use
+of `delay` can be verbose, but helps understand what is going on.
+
+The constructor function `at_most_once` constructs a computation
+that succeeds at most once. If `m` fails, then `at_most_once m`
+fails as well. If `m` produces a result `x`, possibly followed with
+more results, then `at_most_once m` produces just the result `x`,
+and no more. This combinator can be used to commit to a result and
+prevent any other choices from being explored. In other words, it
+limits the amount of backtracking that takes place.
+
+The constructor function `interleave` has the same type as `choose`.
+It is a *fair disjunction* operator. An ordinary disjunction `choose
+m1 m2` gives priority to its left branch: it first lets `e1` produce
+as many results as it wishes, then gives control to `e2`. This can
+be problematic: if `e1` produces a large number of results, then
+`e2` is tried very late. At an extreme, if `e1` produces an infinite
+number of results, then `e2` is never tried. For instance, supposing
+that `evens` produces the infinite sequence `0, 2, 4, ...` and
+`odds` produces the infinite sequence `1, 3, 5, ...`,
+the disjunction `choose evens odds` is equivalent to just `evens`,
+which seems counter-intuitive and undesirable. In contrast,
+`interleave` is defined in such a way that `interleave evens odd`
+produces the infinite sequence `0, 1, 2, 3, 4, 5, ...`.
+It is *fair* in the sense that each branch in turn is allowed
+to produce a result.
+
+The constructor function `(>>-)` has the same type as `(>>=)`.
+It is a *fair sequencing* operator.
+Indeed, a problem with ordinary sequencing `(>>=)` is that
+it gives rise to ordinary (unfair) disjunctions.
+To see this, suppose that the left-hand argument of `(>>=)`
+is a computation that produces `x` as its first result,
+followed with a computation `m1` that may produce more results.
+Thus, this left-hand argument is equivalent to
+`choose (return x) m1`.
+When we sequentially compose it with a computation `m2`,
+we obtain
+`(choose (return x) m1) >>= m2`,
+which is equivalent to
+`choose (return x >>= m2) (m1 >>= m2)`,
+which itself is the same as
+`choose (m2 x) (m1 >>= m2)`.
+We are faced with an ordinary (unfair) disjunction.
+The problem, again, is that if `m2 x` produces an
+infinite number of results, then `m1 >>= m2`
+is never executed.
+To remedy this problem,
+the fair sequencing operator `(>>-)`
+is defined in such a way that
+`choose (return x) m1 >>- m2`
+is equivalent to
+`interleave (m2 x) (m1 >>- m2)`.
+Thus, it gives rise to a fair disjunction.
+
+## The `Seq` API
+
+The type of **on-demand sequences** is defined in a module named `Seq`.
+Beginning with version 4.07,
+this module is part of OCaml's standard library.
+
+```
+module Seq : sig
+
+  type 'a t = unit -> 'a node
+
+  and +'a node =
+  | Nil
+  | Cons of 'a * 'a t
+
+  val nil : 'a t
+  val cons: 'a -> 'a t -> 'a t
+  val singleton: 'a -> 'a t
+
+  val map: ('a -> 'b) -> 'a t -> 'b t
+  val concat: 'a t -> 'a t -> 'a t
+  val flatten: 'a t t -> 'a t
+
+  val take: int -> 'a t -> 'a t
+
+  val head: 'a t -> 'a option
+
+  val of_list: 'a list -> 'a t
+  val to_list: 'a t -> 'a list
+
+end
+```
+
+This data type is closely related to the algebraic data type of lists.
+Indeed, if instead of `unit -> 'a node` one had written just `'a node`,
+then this data type would have been isomorphic to the type of lists.
+
+The presence of `unit -> ...` indicates that a sequence is in fact a function.
+Calling this function, by applying it to the value `()`, amounts to requesting
+the head of the sequence. This head can be either `Nil`, which means that the
+sequence is empty, or `Cons (x, xs)`, which means that the first element of
+the sequence is `x` and the remaining elements form another sequence `xs`. It
+is worth noting that `xs` is itself a function, so the elements of the
+sequence `xs` need not be explicitly computed until `xs` is applied.
+
+Sequences are closely related to *iterators* in object-oriented languages,
+such as C++ and Java. Yet, sequences are much simpler than iterators, for
+two reasons:
+
+* they involve no mutable state;
+
+* they are just as easy to construct and to use as ordinary lists.
+
+The functions `nil`, `cons`, and `singleton` are constructor functions.
+
+The functions `map`, `concat`, `flatten` are analogues for sequences
+of the standard list functions `List.map`, `(@)`, and
+`List.flatten`.
+
+The function `Seq.take` truncates a sequence at a certain length:
+`Seq.take n xs` is a sequence that begins like `xs` but has at most
+`n` elements.
+
+The function `Seq.head` demands the first element of a sequence. If
+the sequence begins with an element `x`, then `Some x` is returned;
+otherwise, `None` is returned. This forces enough computation to
+take place so as to be able to produce the first element of the
+sequence.
+
+The functions `Seq.of_list` and `Seq.to_list` convert between lists
+and sequences, both ways. One must keep in mind that applying
+`Seq.to_list` to a sequence `xs` causes all of its elements to be
+demanded: that is, it forces all of the suspended computations to
+take place. In particular, if `xs` is an infinite sequence, then
+`Seq.to_list xs` does not terminate.
+
+## Implementing the Nondeterminism Monad
+
+In this exercise, we **implement** the nondeterminism monad by representing a
+computation as a function that receives two **continuations** as arguments: a
+success continuation and a failure continuation. The idea is, a computation
+that wishes to produce a result does so by invoking its success continuation;
+a computation that wishes to indicate the absence of a result does so by
+invoking its failure continuation.
+
+A **failure continuation** takes no argument. Thus, its argument type is
+`unit`. Its result type does not concern us at this point; it is chosen at a
+higher level by whoever runs the whole process. We use a type variable
+`'answer` for this type, and we make it a parameter. Thus, the type of a
+failure continuation, `'answer failure`, is as follows:
+
+```
+  type 'answer failure =
+    unit -> 'answer
+```
+
+A **success continuation** takes two arguments. Its first argument is the
+result `x` that we wish to produce now. Its second argument is a failure
+continuation that the outside world can use if they are not happy with `x`: by
+invoking this failure continuation, they give control back to us, which allows
+us to continue and possibly produce another result (by invoking our success
+continuation again!) or fail (by invoking our failure continuation). The
+result type of a success continuation is again `'answer`. Thus, the type of
+a success continuation, `('a, 'answer) success`, is as follows:
+
+```
+  type ('a, 'answer) success =
+    'a -> 'answer failure -> 'answer
+```
+
+It is important to meditate on the previous paragraph, which tells us that
+failure continuations are used in two (dual) ways. We *call a failure
+continuation* that was given to us when we wish to tell the outside world that
+we cannot produce another result. We *build a failure continuation* and pass
+it to the outside world when we are about to produce a result and we wish to
+give the outside world the ability to reject this result.
+
+A **computation** is a function that receives a success continuation and a
+failure continuation and invokes one of them, thereby (eventually) returning
+an answer. A computation does not care what the answer type is: thus, it is
+polymorphic in the type variable `'answer`. This is encoded in OCaml via the
+following (unfortunately somewhat verbose) type definition:
+
+```
+  type 'a m = {
+    compute:
+      'answer .
+        ('a, 'answer) success -> 'answer failure -> 'answer
+  }
+```
+
+This type definition states that a computation is a record type with just one
+field, named `compute`, which contains a polymorphic function of one success
+continuation and one failure continuation to an answer. (We have to introduce
+a record of one field because this is the only way in OCaml of manipulating
+first-class polymorphic functions.)
+
+It is worth noting that, because a `compute` function is polymorphic in
+`'answer`, it cannot return without invoking either its success continuation
+or failure continuation *at least once*.
+
+Furthermore, although this is not expressed in its type, a `compute` function
+may invoke its failure continuation *at most once*. Indeed, one can think of
+invoking a failure continuation as returning `Nil`, and in a sequence of
+results, there is at most one `Nil` constructor. (There is none in an infinite
+sequence.) This analogy also explains why a failure continuation takes no
+argument: this is because `Nil` carries no argument.
+
+A `compute` function may invoke its success continuation *zero, one or more
+times*. Indeed, one can think of invoking a success continuation as returning
+`Cons`, and in a sequence of results, there can be any number of `Cons`
+constructors. This analogy also explains why a success continuation takes two
+arguments, namely a result and a (failure) continuation: this is because
+`Cons` carries two arguments, namely a result and a sequence of remaining
+results.
+
+The analogy between failure and success continuations, on the one hand,
+and the data constructors `Nil` and `Cons`, on the other hand,
+is no accident. The type `'a m` above is in fact the
+[Church encoding](https://en.wikipedia.org/wiki/Church_encoding)
+of the type `'a Seq.t` of sequences.
+
+**Question 1.** Implement the four constructor functions
+`return`, `(>>=)`, `fail`, and `choose`. Implement the
+observation function `sols`.
+
+*Hint.* Although this question requires a lot of care,
+the solution is simple: each of these functions can be
+implemented in one line.
+
+*Note.* The automated grading system first tests whether your code
+is functionally correct. To do so, it builds a computation using the
+four constructor functions, converts it to a sequence via `sols`,
+and tests whether this produces the expected sequence of results.
+Then, it tests whether your code is lazy, that is, whether each
+result is computed as late as possible. To do so, it uses a
+constructor function `tick: 'a m -> 'a m` whose effect is as
+follows: the computation `tick m` produces the same sequence of
+results as the computation `m`, and, when executed, increments a
+global counter named `work`. Thus, by executing computations that
+contain `tick`s, the automated grading system can tell when
+computations are executed. For instance, demanding just the first
+result of the computation
+`choose (tick (return 0)) (tick (return 1))` should cause `work` to
+be incremented just once, not twice.
+
+Before attacking Questions 2-4, we must introduce a couple of auxiliary
+functions: `reflect` and `msplit`.
+
+The need for `msplit` arises from the following remark. When executed, a
+computation of type `'a m` produces a sequence of results. Such a sequence
+must be either empty or nonempty, and in the latter case, it must have a first
+element and a remainder. If a computation *was* just a sequence (that is, if
+the type `'a m` was a synonym for `'a Seq.t`), then we could distinguish these
+two situations just by performing a case analysis.
+
+Because we have defined the type `'a m` in a different way, a direct case
+analysis is impossible. Instead, the idea is to define a function `msplit`
+that *converts* from the type `'a m` to the type `unit -> ('a * 'a m) option`.
+This opens the door to a case analysis. In short, `msplit` allows us to
+perform case analysis on a computation *as if* it was a sequence, even though
+its internal representation is different.
+
+The function `reflect` performs this conversion in the reverse direction:
+it converts a function of type `unit -> ('a * 'a m) option`
+to a computation of type `'a m`. Somewhat surprisingly, the
+need for `reflect` arises in the implementation of `msplit` itself,
+so we implement `reflect` first, followed with `msplit`.
+
+**Question X.** (Not graded.)
+Complete the implementation of the auxiliary functions `reflect` and `msplit.`
+
+*Note.* The function `msplit` and `sols` are closely related. Indeed, they
+both allow performing case analysis on a computation and distinguishing
+whether it fails or produces at least one result. `msplit` and `sols` differ
+in their return types: `msplit` produces an option, whereas `sols` produces a
+sequence. It is in fact possible to use `msplit` in the definition of `sols`;
+we have preferred to ask for a direct definition of `sols` above.
+
+**Question 2.** Implement the constructor function `at_most_once`.
+
+*Hint.* Use `msplit` to determine if the computation at hand fails or produces
+at least one result. In the first case, recall that `at_most_once fail` is
+supposed to behave like `fail`. In the second case, recall that
+`at_most_once (choose (return x) m)` is supposed to behave like
+`return x`.
+
+*Hint.* Use `delay` to ensure that the case analysis is performed when
+the computation `at_most_once m` is *executed*, not when it is *built*.
+
+**Question 3.** Implement the constructor function `interleave`.
+
+*Hint.* Again, use `delay` and `msplit` in an appropriate manner.
+Then, ask yourself how `interleave fail m2` is supposed to behave,
+and how `interleave (choose (return x1) m1) m2` is supposed
+to behave.
+
+**Question 4.** Implement the constructor function `(>>-)`.
+
+*Hint.* Again, use `delay` and `msplit` in an appropriate manner.
+Then, ask yourself how `fail >>- m2` is supposed to behave,
+and how `(choose (return x1) m1) >>- m2` is supposed
+to behave.
+
+## Notes
+
+This exercise is based on the paper
+**"Backtracking, Interleaving, and Terminating Monad Transformers"**
+[(Kiselyov, Shan, Friedman, and Sabry, 2005)](http://okmij.org/ftp/papers/LogicT.pdf).
+One of their key ideas is to propose the operation `msplit`,
+which offers a *view* of a computation as a sequence.
+Based on this operation, many operations, including `at_most_once`,
+`interleave` and `(>>-)` above, and more,
+can be defined *outside* the abstraction barrier of the type `'a m`.
+
+It is important to note that this paper uses Haskell, a lazy programming
+language, where computations are suspended by default. Thus, where it uses
+lists, we cannot use OCaml lists; we must instead use OCaml sequences.
+Furthermore, we must sometimes be careful to explicitly delay computations:
+our `delay` constructor serves this purpose.
+
+The paper goes beyond us by implementing nondeterminism not just as a monad,
+but as a **monad transformer**. Monad transformers can be composed. For
+instance, by composing the nondeterminism monad transformer and the state
+monad transformer, one can describe computations that involve both
+nondeterminism and mutable state.
+
+In this exercise, a nondeterministic computation is represented as a `compute`
+function, which expects a success continuation and a failure continuation as
+arguments. We have noted above that these continuations are analogous to the
+data constructors `Seq.Nil` and `Seq.Cons`. This is no accident: the type `'a
+m` above is in fact the
+[Church encoding](https://en.wikipedia.org/wiki/Church_encoding)
+of the type `'a Seq.t` of sequences.
+
+The continuation-based representation is more efficient than the
+sequence-based representation investigated in
+<a href="" onclick="top.location='/exercises/nondet_monad_seq/';">another exercise</a>.
+This is evident in the implementation of `choose`,
+where there is no per-element cost.
+In particular, the left-leaning computation
+`choose (choose (choose (... (choose 0 1) ...) (n-2)) (n-1)) n`
+is executed in time O(n).
+
+The continuation-based implementation could be criticized on the basis that it
+is rather mysterious. The three main components (failure
+continuations; success continuations; computations) are represented as
+first-class functions. The OCaml compiler represents these functions in the
+heap as closures. Collectively, these closures form a data structure, whose
+shape is unfortunately not evident. In a
+<a href="" onclick="top.location='/exercises/nondet_monad_defun/';">companion exercise</a>,
+we investigate a *defunctionalized* version of this code,
+where failure continuations, success continuations, and computations
+are explicitly represented as data structures,
+described by generalized algebraic data types.

--- a/exercises/nondet_monad_cont/descr.md
+++ b/exercises/nondet_monad_cont/descr.md
@@ -32,8 +32,9 @@ following key elements:
 
 * A single observation function, `sols: 'a m -> 'a Seq.t`, which
   converts a computation to a sequence of results, thereby allowing
-  the user to execute this computation and observe its results. The
-  name `sols` stands for `solutions`.
+  the user to execute this computation and observe its results.
+  (More information on the module `Seq` is given further on.)
+  The name `sols` stands for `solutions`.
 
 A monad can be thought of as a **mini-programming language** where
 computations are first-class citizens: we have a type of
@@ -87,7 +88,7 @@ of type `'a`.
 
 To execute a computation `m`, one must first convert it to a
 sequence of type `'a Seq.t`, whose elements can then be demanded,
-one by one. (More information on the module `Seq` is given below.)
+one by one.
 This conversion is performed by the observation function `sols`.
 
 The call `sols m` typically terminates in constant time; the actual

--- a/exercises/nondet_monad_cont/descr.md
+++ b/exercises/nondet_monad_cont/descr.md
@@ -101,7 +101,7 @@ result.
 
 The constructor functions `return` and `(>>=)` exist in all monads.
 (They are also known as `return` and `bind`.) `return` constructs a
-trivial computation, which does nothing except return a value,
+trivial computation, which does nothing but return a value,
 whereas `(>>=)` constructs the sequential composition of two
 computations. Together, they allow constructing the sequential
 composition of an arbitrary number of computations.

--- a/exercises/nondet_monad_cont/descr.md
+++ b/exercises/nondet_monad_cont/descr.md
@@ -134,7 +134,7 @@ computations.
   and by `m2`.
 
 The constructor function `delay` is used to delay the construction
-of a computation until the moment where this computation must be
+of a computation until the moment when this computation must be
 executed. Indeed, a difficulty that arises in a strict programming
 language, such as OCaml, is that the arguments passed to constructor
 functions, such as `return` and `choose`, are evaluated immediately,

--- a/exercises/nondet_monad_cont/descr.md
+++ b/exercises/nondet_monad_cont/descr.md
@@ -42,7 +42,7 @@ computations.
 
 A computation in the nondeterminism monad can produce zero, one, or
 more results. Indeed, a computation that fails produces zero
-results. A computation that succeeds normally produces one result.
+result. A computation that succeeds normally produces one result.
 A computation that uses `choose` can produce more than one result.
 It is in fact possible to construct computations that produce an
 infinite number of results!

--- a/exercises/nondet_monad_cont/master.ml
+++ b/exercises/nondet_monad_cont/master.ml
@@ -1,0 +1,150 @@
+let return (x : 'a) : 'a m =
+(* BEGIN INCLUDE *)
+  (* TO DO: Define this function. *)
+  raise TODO
+(*   END INCLUDE *)
+(* BEGIN EXCLUDE
+  let compute s f = s x f in
+  { compute }
+  (* We are able to produce the result [x]. To do so, we invoke the
+     success continuation [s] with [x]. Because we are unable to produce
+     more results, if the outside world requests more results from us,
+     we must fail; to indicate this, we directly pass our own failure
+     continuation [f] to [s]. This is a tail call in CPS style. *)
+     END EXCLUDE *)
+
+let (>>=) (m1 : 'a m) (m2 : 'a -> 'b m) : 'b m =
+(* BEGIN INCLUDE *)
+  (* TO DO: Define this function. *)
+  raise TODO
+(*   END INCLUDE *)
+(* BEGIN EXCLUDE
+  let compute s f = m1.compute (fun x f' -> (m2 x).compute s f') f in
+  { compute }
+  (* In order to produce anything, we must first execute [m1]. If it
+     fails, we fail as well; we indicate this by passing [f] as the
+     failure continuation. Every time [m1] produces an element [x],
+     we execute the computation [m2 x]. Every result produced by it
+     is passed directly to our success continuation [s]. If and when
+     [m2 x] fails, we must request the next [x], which is done by
+     calling [f'], the failure continuation that came with [x]. *)
+     END EXCLUDE *)
+
+let fail : 'a m =
+(* BEGIN INCLUDE *)
+  (* TO DO: Define this constant. (Delete the whole line.) *)
+  delay (fun () -> raise TODO)
+(*   END INCLUDE *)
+(* BEGIN EXCLUDE
+  let compute s f = f() in
+  { compute }
+  (* We are unable to produce any result, so we immediately invoke
+     the failure continuation [f]. *)
+     END EXCLUDE *)
+
+let choose (m1 : 'a m) (m2 : 'a m) : 'a m =
+(* BEGIN INCLUDE *)
+  (* TO DO: Define this function. *)
+  raise TODO
+(*   END INCLUDE *)
+(* BEGIN EXCLUDE
+  let compute s f = m1.compute s (fun () -> m2.compute s f) in
+  { compute }
+  (* We first execute [m1] and let it pass each of its results directly
+     to [s]. Once it is done, it fails and calls the failure continuation
+     that we have built. There, we execute [m2] and let it pass each of
+     its results directly to [s]. Once it is done, it fails; we provide
+     our own failure continuation [f] to it, so that this failure propagates
+     upwards without passing through us. *)
+     END EXCLUDE *)
+
+let sols (m : 'a m) : 'a Seq.t =
+(* BEGIN INCLUDE *)
+  (* TO DO: Define this function. *)
+  raise TODO
+(*   END INCLUDE *)
+(* BEGIN EXCLUDE
+  fun () ->
+    m.compute
+      (fun x f -> Seq.Cons (x, f))
+      (fun () -> Seq.Nil)
+     END EXCLUDE *)
+
+let reflect (o : unit -> ('a * 'a m) option) : 'a m =
+  delay (fun () ->
+    match o() with
+    | None ->
+(* BEGIN INCLUDE *)
+        (* TO DO: Complete this definition. *)
+        raise TODO
+(*   END INCLUDE *)
+(* BEGIN EXCLUDE
+        fail
+     END EXCLUDE *)
+    | Some (x, m) ->
+(* BEGIN INCLUDE *)
+        (* TO DO: Complete this definition. *)
+        raise TODO
+(*   END INCLUDE *)
+(* BEGIN EXCLUDE
+        choose (return x) m
+     END EXCLUDE *)
+  )
+
+let msplit (m : 'a m) : unit -> ('a * 'a m) option =
+  fun () ->
+    m.compute
+(* BEGIN INCLUDE *)
+      (* TO DO: Complete this definition. *)
+      (fun x f -> raise TODO)
+      (fun  () -> raise TODO)
+(*   END INCLUDE *)
+(* BEGIN EXCLUDE
+      (fun x f -> Some (x, reflect f))
+      (fun  () -> None)
+     END EXCLUDE *)
+
+let at_most_once (m : 'a m) : 'a m =
+(* BEGIN INCLUDE *)
+  (* TO DO: Define this function. *)
+  raise TODO
+(*   END INCLUDE *)
+(* BEGIN EXCLUDE
+  delay (fun () ->
+    match msplit m () with
+    | None ->
+        fail
+    | Some (x, _) ->
+        return x
+  )
+     END EXCLUDE *)
+
+let rec interleave (m1 : 'a m) (m2 : 'a m) : 'a m =
+(* BEGIN INCLUDE *)
+  (* TO DO: Define this function. *)
+  raise TODO
+(*   END INCLUDE *)
+(* BEGIN EXCLUDE
+  delay (fun () ->
+    match msplit m1 () with
+    | None ->
+        m2
+    | Some (x1, m1) ->
+        choose (return x1) (interleave m2 m1)
+  )
+     END EXCLUDE *)
+
+let rec (>>-) (m1 : 'a m) (m2 : 'a -> 'b m) : 'b m =
+(* BEGIN INCLUDE *)
+  (* TO DO: Define this function. *)
+  raise TODO
+(*   END INCLUDE *)
+(* BEGIN EXCLUDE
+  delay (fun () ->
+    match msplit m1 () with
+    | None ->
+        fail
+    | Some (x1, m1) ->
+        interleave (m2 x1) (m1 >>- m2)
+  )
+     END EXCLUDE *)

--- a/exercises/nondet_monad_cont/meta.json
+++ b/exercises/nondet_monad_cont/meta.json
@@ -1,0 +1,6 @@
+{
+  "learnocaml_version":"1",
+  "kind":"exercise",
+  "stars":3,
+  "title":"Implementing Nondeterminism with Continuations"
+}

--- a/exercises/nondet_monad_cont/prelude.ml
+++ b/exercises/nondet_monad_cont/prelude.ml
@@ -1,0 +1,133 @@
+(* The module [Seq] is standard as of OCaml 4.07. *)
+
+module Seq = struct
+
+  type 'a t = unit -> 'a node
+
+  and +'a node =
+  | Nil
+  | Cons of 'a * 'a t
+
+  let nil =
+    fun () -> Nil
+
+  let cons x xs =
+    fun () -> Cons (x, xs)
+
+  let singleton x =
+    cons x nil
+
+  let rec map (f : 'a -> 'b) (xs : 'a t) : 'b t =
+    fun () ->
+      match xs() with
+      | Nil ->
+          Nil
+      | Cons (x, xs) ->
+          Cons (f x, map f xs)
+
+  let rec concat (xs : 'a t) (ys : 'a t) : 'a t =
+    fun () ->
+      match xs() with
+      | Nil ->
+          ys()
+      | Cons (x, xs) ->
+          Cons (x, concat xs ys)
+
+  let rec flatten (xss : 'a t t) : 'a t =
+    fun () ->
+      match xss() with
+      | Nil ->
+          Nil
+      | Cons (xs, xss) ->
+          concat xs (flatten xss) ()
+
+  let rec take n (xs : 'a t) : 'a t =
+    if n = 0 then
+      nil
+    else
+      fun () ->
+        match xs() with
+        | Nil ->
+            Nil
+        | Cons (x, xs) ->
+            Cons (x, take (n-1) xs)
+
+  let head (xs : 'a t) : 'a option =
+    match xs() with
+    | Nil ->
+        None
+    | Cons (x, _) ->
+        Some x
+
+  let rec of_list (xs : 'a list) : 'a t =
+    fun () ->
+      match xs with
+      | [] ->
+          Nil
+      | x :: xs ->
+          Cons (x, of_list xs)
+
+  (* A word of warning: [to_list] does not terminate if it is applied
+     to an infinite sequence. Furthermore, this version of [to_list]
+     is not tail-recursive and could exhaust the stack space if it was
+     applied to a long sequence. *)
+
+  let rec to_list (xs : 'a t) : 'a list =
+    match xs() with
+    | Nil ->
+        []
+    | Cons (x, xs) ->
+        x :: to_list xs
+
+end
+
+(* A failure continuation takes no argument and returns a final answer. *)
+
+type 'answer failure =
+  unit -> 'answer
+
+(* A success continuation takes one argument (a result) and returns a final
+   answer. *)
+
+type ('a, 'answer) success =
+  'a -> 'answer failure -> 'answer
+
+(* A nondeterministic computation produces a sequence of results.
+   It is represented (in this implementation) as a function [compute]
+   which accepts a success continuation [s] and a failure continuation [f].
+   It is polymorphic in the answer type of these continuations. *)
+
+(* The OCaml annotation [@@unboxed] improves efficiency, but otherwise
+   has no impact. *)
+
+type 'a m = {
+  compute: 'answer . ('a, 'answer) success -> 'answer failure -> 'answer
+} [@@unboxed]
+
+(* In the implementation of [delay], the function call [m()] takes place
+   only when [compute] is invoked -- not right now. *)
+
+let delay (m : unit -> 'a m) : 'a m =
+  let compute s f = (m()).compute s f in
+  { compute }
+
+(* The effect of executing the computation [tick m] is to first increment the
+   global counter [work], then execute the computation [m]. *)
+
+(* The grading code uses these operations in order to check that computations
+   are executed on demand, that is, as late as possible. *)
+
+let work =
+  ref 0
+
+let reset() =
+  work := 0
+
+let tick (m : 'a m) : 'a m =
+  delay (fun () ->
+    work := !work + 1;
+    m
+  )
+
+let snapshot (x : 'a) : 'a * int =
+  (x, !work)

--- a/exercises/nondet_monad_cont/prepare.ml
+++ b/exercises/nondet_monad_cont/prepare.ml
@@ -1,0 +1,1 @@
+exception TODO

--- a/exercises/nondet_monad_cont/solution.log
+++ b/exercises/nondet_monad_cont/solution.log
@@ -1,0 +1,2 @@
+Learnocaml v.0.10 running.
+[ Loading the prelude. ][K[ Preparing the test environment. ][K[ Loading your code. ][K[ Loading the solution. ][K[ Preparing to launch the tests. ][K[ Launching the test bench. ][K.                              - Success - 8 points

--- a/exercises/nondet_monad_cont/solution.ml
+++ b/exercises/nondet_monad_cont/solution.ml
@@ -1,0 +1,83 @@
+let return (x : 'a) : 'a m =
+  let compute s f = s x f in
+  { compute }
+  (* We are able to produce the result [x]. To do so, we invoke the
+     success continuation [s] with [x]. Because we are unable to produce
+     more results, if the outside world requests more results from us,
+     we must fail; to indicate this, we directly pass our own failure
+     continuation [f] to [s]. This is a tail call in CPS style. *)
+
+let (>>=) (m1 : 'a m) (m2 : 'a -> 'b m) : 'b m =
+  let compute s f = m1.compute (fun x f' -> (m2 x).compute s f') f in
+  { compute }
+  (* In order to produce anything, we must first execute [m1]. If it
+     fails, we fail as well; we indicate this by passing [f] as the
+     failure continuation. Every time [m1] produces an element [x],
+     we execute the computation [m2 x]. Every result produced by it
+     is passed directly to our success continuation [s]. If and when
+     [m2 x] fails, we must request the next [x], which is done by
+     calling [f'], the failure continuation that came with [x]. *)
+
+let fail : 'a m =
+  let compute s f = f() in
+  { compute }
+  (* We are unable to produce any result, so we immediately invoke
+     the failure continuation [f]. *)
+
+let choose (m1 : 'a m) (m2 : 'a m) : 'a m =
+  let compute s f = m1.compute s (fun () -> m2.compute s f) in
+  { compute }
+  (* We first execute [m1] and let it pass each of its results directly
+     to [s]. Once it is done, it fails and calls the failure continuation
+     that we have built. There, we execute [m2] and let it pass each of
+     its results directly to [s]. Once it is done, it fails; we provide
+     our own failure continuation [f] to it, so that this failure propagates
+     upwards without passing through us. *)
+
+let sols (m : 'a m) : 'a Seq.t =
+  fun () ->
+    m.compute
+      (fun x f -> Seq.Cons (x, f))
+      (fun () -> Seq.Nil)
+
+let reflect (o : unit -> ('a * 'a m) option) : 'a m =
+  delay (fun () ->
+    match o() with
+    | None ->
+        fail
+    | Some (x, m) ->
+        choose (return x) m
+  )
+
+let msplit (m : 'a m) : unit -> ('a * 'a m) option =
+  fun () ->
+    m.compute
+      (fun x f -> Some (x, reflect f))
+      (fun  () -> None)
+
+let at_most_once (m : 'a m) : 'a m =
+  delay (fun () ->
+    match msplit m () with
+    | None ->
+        fail
+    | Some (x, _) ->
+        return x
+  )
+
+let rec interleave (m1 : 'a m) (m2 : 'a m) : 'a m =
+  delay (fun () ->
+    match msplit m1 () with
+    | None ->
+        m2
+    | Some (x1, m1) ->
+        choose (return x1) (interleave m2 m1)
+  )
+
+let rec (>>-) (m1 : 'a m) (m2 : 'a -> 'b m) : 'b m =
+  delay (fun () ->
+    match msplit m1 () with
+    | None ->
+        fail
+    | Some (x1, m1) ->
+        interleave (m2 x1) (m1 >>- m2)
+  )

--- a/exercises/nondet_monad_cont/solution.report.txt
+++ b/exercises/nondet_monad_cont/solution.report.txt
@@ -1,0 +1,46 @@
+Question 1
+  Found [return] with compatible type.
+  Found [>>=] with compatible type.
+  Found [fail] with compatible type.
+  Found [choose] with compatible type.
+  Found [sols] with compatible type.
+  Functional correctness
+    Success 1: The code seems correct. Tested 2411 scenarios.
+  Laziness
+    Success 1: The code seems lazy.
+Question 2
+  Found [return] with compatible type.
+  Found [>>=] with compatible type.
+  Found [fail] with compatible type.
+  Found [choose] with compatible type.
+  Found [sols] with compatible type.
+  Found [at_most_once] with compatible type.
+  Functional correctness
+    Success 1: The code seems correct. Tested 2486 scenarios.
+  Laziness
+    Success 1: The code seems lazy.
+Question 3
+  Found [return] with compatible type.
+  Found [>>=] with compatible type.
+  Found [fail] with compatible type.
+  Found [choose] with compatible type.
+  Found [sols] with compatible type.
+  Found [at_most_once] with compatible type.
+  Found [interleave] with compatible type.
+  Functional correctness
+    Success 1: The code seems correct. Tested 2867 scenarios.
+  Laziness
+    Success 1: The code seems lazy.
+Question 4
+  Found [return] with compatible type.
+  Found [>>=] with compatible type.
+  Found [fail] with compatible type.
+  Found [choose] with compatible type.
+  Found [sols] with compatible type.
+  Found [at_most_once] with compatible type.
+  Found [interleave] with compatible type.
+  Found [>>-] with compatible type.
+  Functional correctness
+    Success 1: The code seems correct. Tested 10356 scenarios.
+  Laziness
+    Success 1: The code seems lazy.

--- a/exercises/nondet_monad_cont/template.ml
+++ b/exercises/nondet_monad_cont/template.ml
@@ -1,0 +1,49 @@
+let return (x : 'a) : 'a m =
+  (* TO DO: Define this function. *)
+  raise TODO
+
+let (>>=) (m1 : 'a m) (m2 : 'a -> 'b m) : 'b m =
+  (* TO DO: Define this function. *)
+  raise TODO
+
+let fail : 'a m =
+  (* TO DO: Define this constant. (Delete the whole line.) *)
+  delay (fun () -> raise TODO)
+
+let choose (m1 : 'a m) (m2 : 'a m) : 'a m =
+  (* TO DO: Define this function. *)
+  raise TODO
+
+let sols (m : 'a m) : 'a Seq.t =
+  (* TO DO: Define this function. *)
+  raise TODO
+
+let reflect (o : unit -> ('a * 'a m) option) : 'a m =
+  delay (fun () ->
+    match o() with
+    | None ->
+        (* TO DO: Complete this definition. *)
+        raise TODO
+    | Some (x, m) ->
+        (* TO DO: Complete this definition. *)
+        raise TODO
+  )
+
+let msplit (m : 'a m) : unit -> ('a * 'a m) option =
+  fun () ->
+    m.compute
+      (* TO DO: Complete this definition. *)
+      (fun x f -> raise TODO)
+      (fun  () -> raise TODO)
+
+let at_most_once (m : 'a m) : 'a m =
+  (* TO DO: Define this function. *)
+  raise TODO
+
+let rec interleave (m1 : 'a m) (m2 : 'a m) : 'a m =
+  (* TO DO: Define this function. *)
+  raise TODO
+
+let rec (>>-) (m1 : 'a m) (m2 : 'a -> 'b m) : 'b m =
+  (* TO DO: Define this function. *)
+  raise TODO

--- a/exercises/nondet_monad_cont/test.ml
+++ b/exercises/nondet_monad_cont/test.ml
@@ -1,0 +1,1530 @@
+open Printf
+let iter = List.iter
+let map = List.map
+module T = Test_lib
+module R = Report
+type report = R.t
+(* Determinism. *)
+let () = Random.init 0
+
+(* The auto-grader. *)
+
+(* -------------------------------------------------------------------------- *)
+
+(* Some of the code below should move to separate library files. *)
+
+(* -------------------------------------------------------------------------- *)
+
+(* PPrintMini. *)
+
+(* -------------------------------------------------------------------------- *)
+
+(* A type of integers with infinity. *)
+
+type requirement =
+    int (* with infinity *)
+
+(* Infinity is encoded as [max_int]. *)
+
+let infinity : requirement =
+  max_int
+
+(* Addition of integers with infinity. *)
+
+let (++) (x : requirement) (y : requirement) : requirement =
+  if x = infinity || y = infinity then
+    infinity
+  else
+    x + y
+
+(* Comparison between an integer with infinity and a normal integer. *)
+
+let (<==) (x : requirement) (y : int) =
+  x <= y
+
+(* -------------------------------------------------------------------------- *)
+
+(* The type of documents. See [PPrintEngine] for documentation. *)
+
+type document =
+  | Empty
+  | FancyString of string * int * int * int
+  | Blank of int
+  | IfFlat of document * document
+  | HardLine
+  | Cat of requirement * document * document
+  | Nest of requirement * int * document
+  | Group of requirement * document
+
+(* -------------------------------------------------------------------------- *)
+
+(* Retrieving or computing the space requirement of a document. *)
+
+let rec requirement = function
+  | Empty ->
+      0
+  | FancyString (_, _, _, len)
+  | Blank len ->
+      len
+  | IfFlat (doc1, _) ->
+      requirement doc1
+  | HardLine ->
+      infinity
+  | Cat (req, _, _)
+  | Nest (req, _, _)
+  | Group (req, _) ->
+      req
+
+(* -------------------------------------------------------------------------- *)
+
+(* Document constructors. *)
+
+let empty =
+  Empty
+
+let fancysubstring s ofs len apparent_length =
+  if len = 0 then
+    empty
+  else
+    FancyString (s, ofs, len, apparent_length)
+
+let fancystring s apparent_length =
+  fancysubstring s 0 (String.length s) apparent_length
+
+let utf8_length s =
+  let rec length_aux s c i =
+    if i >= String.length s then c else
+    let n = Char.code (String.unsafe_get s i) in
+    let k =
+      if n < 0x80 then 1 else
+      if n < 0xe0 then 2 else
+      if n < 0xf0 then 3 else 4
+    in
+    length_aux s (c + 1) (i + k)
+  in
+  length_aux s 0 0
+
+let utf8string s =
+  fancystring s (utf8_length s)
+
+let utf8format f =
+  ksprintf utf8string f
+
+let char c =
+  assert (c <> '\n');
+  fancystring (String.make 1 c) 1
+
+let space =
+  char ' '
+
+let semicolon =
+  char ';'
+
+let hardline =
+  HardLine
+
+let blank n =
+  match n with
+  | 0 ->
+      empty
+  | 1 ->
+      space
+  | _ ->
+      Blank n
+
+let ifflat doc1 doc2 =
+  match doc1 with
+  | IfFlat (doc1, _)
+  | doc1 ->
+      IfFlat (doc1, doc2)
+
+let internal_break i =
+  ifflat (blank i) hardline
+
+let break0 =
+  internal_break 0
+
+let break1 =
+  internal_break 1
+
+let break i =
+  match i with
+  | 0 ->
+      break0
+  | 1 ->
+      break1
+  | _ ->
+      internal_break i
+
+let (^^) x y =
+  match x, y with
+  | Empty, _ ->
+      y
+  | _, Empty ->
+      x
+  | _, _ ->
+      Cat (requirement x ++ requirement y, x, y)
+
+let nest i x =
+  assert (i >= 0);
+  Nest (requirement x, i, x)
+
+let group x =
+  let req = requirement x in
+  if req = infinity then
+    x
+  else
+    Group (req, x)
+
+(* -------------------------------------------------------------------------- *)
+
+(* Printing blank space (indentation characters). *)
+
+let blank_length =
+  80
+
+let blank_buffer =
+  String.make blank_length ' '
+
+let rec blanks output n =
+  if n <= 0 then
+    ()
+  else if n <= blank_length then
+    Buffer.add_substring output blank_buffer 0 n
+  else begin
+    Buffer.add_substring output blank_buffer 0 blank_length;
+    blanks output (n - blank_length)
+  end
+
+(* -------------------------------------------------------------------------- *)
+
+(* The rendering engine maintains the following internal state. *)
+
+(* For simplicity, the ribbon width is considered equal to the line
+   width; in other words, there is no ribbon width constraint. *)
+
+(* For simplicity, the output channel is required to be an OCaml buffer.
+   It is stored within the [state] record. *)
+
+type state =
+  {
+    (* The line width. *)
+    width: int;
+    (* The current column. *)
+    mutable column: int;
+    (* The output buffer. *)
+    mutable output: Buffer.t;
+  }
+
+(* -------------------------------------------------------------------------- *)
+
+(* For simplicity, the rendering engine is *not* in tail-recursive style. *)
+
+let rec pretty state (indent : int) (flatten : bool) doc =
+  match doc with
+
+  | Empty ->
+      ()
+
+  | FancyString (s, ofs, len, apparent_length) ->
+      Buffer.add_substring state.output s ofs len;
+      state.column <- state.column + apparent_length
+
+  | Blank n ->
+      blanks state.output n;
+      state.column <- state.column + n
+
+  | HardLine ->
+      assert (not flatten);
+      Buffer.add_char state.output '\n';
+      blanks state.output indent;
+      state.column <- indent
+
+  | IfFlat (doc1, doc2) ->
+      pretty state indent flatten (if flatten then doc1 else doc2)
+
+  | Cat (_, doc1, doc2) ->
+      pretty state indent flatten doc1;
+      pretty state indent flatten doc2
+
+  | Nest (_, j, doc) ->
+      pretty state (indent + j) flatten doc
+
+  | Group (req, doc) ->
+      let flatten = flatten || state.column ++ req <== state.width in
+      pretty state indent flatten doc
+
+(* -------------------------------------------------------------------------- *)
+
+(* The engine's entry point. *)
+
+let pretty width doc =
+  let output = Buffer.create 512 in
+  let state = { width; column = 0; output } in
+  pretty state 0 false doc;
+  Buffer.contents output
+
+(* -------------------------------------------------------------------------- *)
+
+(* Additions to PPrintMini. *)
+
+let separate (sep : 'a) (xs : 'a list) : 'a list =
+  match xs with
+  | [] ->
+      []
+  | x :: xs ->
+      x :: List.flatten (List.map (fun x -> [sep; x]) xs)
+
+let concat (docs : document list) : document =
+  List.fold_right (^^) docs empty
+
+let comma =
+  utf8string "," ^^ break 1
+
+let commas docs =
+  concat (separate comma docs)
+
+let semi =
+  utf8string ";" ^^ break 1
+
+let semis docs =
+  concat (separate semi docs)
+
+let int i =
+  utf8format "%d" i
+
+let block doc =
+  nest 2 (break 0 ^^ doc) ^^ break 0
+
+let parens doc =
+  utf8string "(" ^^ block doc ^^ utf8string ")"
+
+let brackets doc =
+  utf8string "[" ^^ block doc ^^ utf8string "]"
+
+let ocaml_array_brackets doc =
+  utf8string "[| " ^^ block doc ^^ utf8string "|]"
+
+let tuple docs =
+  group (parens (commas docs))
+
+let list docs =
+  group (brackets (semis docs))
+
+let construct label docs =
+  match docs with
+  | [] ->
+      utf8string label
+  | _ ->
+      utf8string label ^^ space ^^ tuple docs
+
+let flow docs =
+  match docs with
+  | [] ->
+      []
+  | doc :: docs ->
+      doc :: map (fun doc -> group (break 1) ^^ doc) docs
+
+let raw_apply docs =
+  group (concat (flow docs))
+
+let apply f docs =
+  raw_apply (utf8string f :: docs)
+
+let parens_apply f docs =
+  parens (apply f docs)
+
+let piped_apply f docs =
+  (* Isolate the last argument. *)
+  assert (List.length docs > 0);
+  let docs = List.rev docs in
+  let doc, docs = List.hd docs, List.rev (List.tl docs) in
+  (* Print. *)
+  group (doc ^^ break 1 ^^ utf8string "|>" ^^ space ^^ apply f docs)
+
+let wrap (print : 'a -> document) : 'a -> string =
+  fun x -> pretty 70 (group (print x))
+
+(* -------------------------------------------------------------------------- *)
+
+(* An implementation of symbolic sequences. *)
+
+module SymSeq = struct
+
+  type _ seq =
+  | Empty    : 'a seq
+  | Singleton: 'a -> 'a seq
+  | Sum      : int * 'a seq * 'a seq -> 'a seq
+  | Product  : int * 'a seq * 'b seq -> ('a * 'b) seq
+  | Map      : int * ('a -> 'b) * 'a seq -> 'b seq
+
+  exception OutOfBounds
+
+  let length (type a) (s : a seq) : int =
+    match s with
+    | Empty ->
+        0
+    | Singleton _ ->
+        1
+    | Sum (length, _, _) ->
+        length
+    | Product (length, _, _) ->
+        length
+    | Map (length, _, _) ->
+        length
+
+  let is_empty s =
+    length s = 0
+
+  let empty =
+    Empty
+
+  let singleton x =
+    Singleton x
+
+  let sum s1 s2 =
+    if is_empty s1 then s2
+    else if is_empty s2 then s1
+    else Sum (length s1 + length s2, s1, s2)
+
+  let bigsum ss =
+    List.fold_left sum empty ss
+
+  let product s1 s2 =
+    if is_empty s1 || is_empty s2 then
+      empty
+    else
+      Product (length s1 * length s2, s1, s2)
+
+  let map phi s =
+    if is_empty s then
+      empty
+    else
+      Map (length s, phi, s)
+
+  let rec get : type a . a seq -> int -> a =
+    fun s i ->
+      match s with
+      | Empty ->
+          raise OutOfBounds
+      | Singleton x ->
+          if i = 0 then x else raise OutOfBounds
+      | Sum (_, s1, s2) ->
+          let n1 = length s1 in
+          if i < n1 then get s1 i
+          else get s2 (i - n1)
+      | Product (_, s1, s2) ->
+          let q, r = i / length s2, i mod length s2 in
+          get s1 q, get s2 r
+      | Map (_, phi, s) ->
+          phi (get s i)
+
+  let rec foreach : type a . a seq -> (a -> unit) -> unit =
+    fun s k ->
+      match s with
+      | Empty ->
+          ()
+      | Singleton x ->
+          k x
+      | Sum (_, s1, s2) ->
+          foreach s1 k;
+          foreach s2 k
+      | Product (_, s1, s2) ->
+          foreach s1 (fun x1 ->
+            foreach s2 (fun x2 ->
+              k (x1, x2)
+            )
+          )
+      | Map (_, phi, s) ->
+          foreach s (fun x -> k (phi x))
+
+  let elements (s : 'a seq) : 'a list =
+    let xs = ref [] in
+    foreach s (fun x -> xs := x :: !xs);
+    List.rev !xs
+
+  (* Extract a list of at most [threshold] elements from the sequence [s]. *)
+
+  let sample threshold (s : 'a seq) : 'a list =
+    if length s <= threshold then
+      (* If the sequence is short enough, keep of all its elements. *)
+      elements s
+    else
+      (* Otherwise, keep a randomly chosen sample. *)
+      let xs = ref [] in
+      for i = 1 to threshold do
+        let i = Random.int (length s) in
+        let x = get s i in
+        xs := x :: !xs
+      done;
+      !xs
+
+end
+
+type 'a seq =
+  'a SymSeq.seq
+
+(* -------------------------------------------------------------------------- *)
+
+(* A fixed point combinator. *)
+
+let fix : type a b . ((a -> b) -> (a -> b)) -> (a -> b) =
+  fun ff ->
+    let table = Hashtbl.create 128 in
+    let rec f (x : a) : b =
+      try
+        Hashtbl.find table x
+      with Not_found ->
+        let y = ff f x in
+        Hashtbl.add table x y;
+        y
+    in
+    f
+
+let   curry f x y = f (x, y)
+let uncurry f (x, y) = f x y
+
+let fix2 : type a b c . ((a -> b -> c) -> (a -> b -> c)) -> (a -> b -> c) =
+  fun ff ->
+    let ff f = uncurry (ff (curry f)) in
+    curry (fix ff)
+
+(* -------------------------------------------------------------------------- *)
+
+(* MiniFeat. *)
+
+module Feat = struct
+
+  (* Core combinators. *)
+
+  type 'a enum =
+    int -> 'a SymSeq.seq
+
+  let empty : 'a enum =
+    fun _s ->
+      SymSeq.empty
+
+  let zero =
+    empty
+
+  let enum (xs : 'a SymSeq.seq) : 'a enum =
+    fun s ->
+      if s = 0 then xs else SymSeq.empty
+
+  let just (x : 'a) : 'a enum =
+    (* enum (SymSeq.singleton x) *)
+    fun s ->
+      if s = 0 then SymSeq.singleton x else SymSeq.empty
+
+  let pay (enum : 'a enum) : 'a enum =
+    fun s ->
+      if s = 0 then SymSeq.empty else enum (s-1)
+
+  let sum (enum1 : 'a enum) (enum2 : 'a enum) : 'a enum =
+    fun s ->
+      SymSeq.sum (enum1 s) (enum2 s)
+
+  let ( ++ ) =
+    sum
+
+  let rec _up i j =
+    if i <= j then
+      i :: _up (i + 1) j
+    else
+      []
+
+  let product (enum1 : 'a enum) (enum2 : 'b enum) : ('a * 'b) enum =
+    fun s ->
+      SymSeq.bigsum (
+        List.map (fun s1 ->
+          let s2 = s - s1 in
+          SymSeq.product (enum1 s1) (enum2 s2)
+        ) (_up 0 s)
+      )
+
+  let ( ** ) =
+    product
+
+  let balanced_product (enum1 : 'a enum) (enum2 : 'b enum) : ('a * 'b) enum =
+    fun s ->
+      if s mod 2 = 0 then
+        let s = s / 2 in
+        SymSeq.product (enum1 s) (enum2 s)
+      else
+        let s = s / 2 in
+        SymSeq.sum
+          (SymSeq.product (enum1 s) (enum2 (s+1)))
+          (SymSeq.product (enum1 (s+1)) (enum2 s))
+
+  let ( *-* ) =
+    balanced_product
+
+  let map (phi : 'a -> 'b) (enum : 'a enum) : 'b enum =
+    fun s ->
+      SymSeq.map phi (enum s)
+
+  (* Convenience functions. *)
+
+  let finite (xs : 'a list) : 'a enum =
+    List.fold_left (++) zero (List.map just xs)
+
+  let bool : bool enum =
+    just false ++ just true
+
+  let list (elem : 'a enum) : 'a list enum =
+    let cons (x, xs) = x :: xs in
+    fix (fun list ->
+      just [] ++ pay (map cons (elem ** list))
+    )
+
+  (* Extract a list of at most [threshold] elements of each size,
+     for every size up to [s] (included), from the enumeration [e]. *)
+
+  let sample threshold s (e : 'a enum) : 'a list =
+    List.flatten (
+      List.map (fun i ->
+        SymSeq.sample threshold (e i)
+      ) (_up 0 s)
+    )
+
+end
+
+type 'a enum =
+  'a Feat.enum
+
+(* -------------------------------------------------------------------------- *)
+
+(* Generic testing utilities. *)
+
+(* When we fail, the exception carries a learn-ocaml report. *)
+
+exception Fail of report
+
+(* [section title report] encloses the report [report] within a section
+   entitled [title], producing a larger report. *)
+
+let section title report : report =
+  [R.Section ([R.Text title], report)]
+
+(* This generic function takes as an argument the text of the message that
+   will be displayed. A message is a list of inline things. *)
+
+let fail (text : R.inline list) =
+  let report = [R.Message (text, R.Failure)] in
+  raise (Fail report)
+
+(* This is a special case where the message is a singleton list containing
+   a single string. The string can be formatted using a printf format. *)
+
+let fail_text format =
+  Printf.ksprintf (fun s -> fail [R.Text s]) format
+
+(* [protect f] evaluates [f()], which either returns normally and produces a
+   report, or raises [Fail] and produces a report. In either case, the report
+   is returned. *)
+
+(* If an unexpected exception is raised, in student code or in grading code,
+   the exception is displayed as part of a failure report. (Ideally, grading
+   code should never raise an exception!) It is debatable whether one should
+   show just the name of the exception, or a full backtrace; I choose the
+   latter, on the basis that more information is always preferable. *)
+
+let protect f =
+  try
+    T.run_timeout f
+  with
+  | Fail report ->
+      report
+  | TODO ->
+      let text = [
+        R.Text "Not yet implemented."
+      ] in
+      let report = [R.Message (text, R.Failure)] in
+      report
+  | (e : exn) ->
+      let text = [
+        R.Text "The following exception is raised and never caught:";
+        R.Break;
+        R.Output (Printexc.to_string e);
+        R.Output (Printexc.get_backtrace());
+      ] in
+      let report = [R.Message (text, R.Failure)] in
+      report
+
+(* [successful] tests whether a report is successful. *)
+
+let successful_status = function
+  | R.Success _
+  | R.Warning
+  | R.Informative
+  | R.Important ->
+     true
+  | R.Failure ->
+     false
+
+let rec successful_item = function
+  | R.Section (_, r) ->
+      successful r
+  | R.Message (_, status) ->
+      successful_status status
+
+and successful (r : report) =
+  List.for_all successful_item r
+
+let (-@>) (r : report) (f : unit -> report) : report =
+  if successful r then
+    r @ f()
+  else
+    r
+
+(* -------------------------------------------------------------------------- *)
+
+(* Generic test functions. *)
+
+let grab ty name k =
+  T.test_value (T.lookup_student ty name) k
+
+let test_value_0 name ty reference eq =
+  grab ty name (fun candidate ->
+    protect (fun () ->
+      if not (eq candidate reference) then
+        fail [
+          R.Code name; R.Text "is incorrect.";
+        ];
+      let message = [ R.Code name; R.Text "is correct."; ] in
+      [ R.Message (message, R.Success 1) ]
+    )
+  )
+
+let correct name =
+  let message = [ R.Code name; R.Text "seems correct."; ] in
+  [ R.Message (message, R.Success 1) ]
+
+(* When doing black-box testing of a complete module, we are not testing just
+   one function in isolation, but a group of functions together. In that case,
+   the wording of the error message is somewhat different. Instead of saying
+   that a specific function is incorrect, we want to say that an expression
+   [expr] yields an incorrect result. *)
+
+let eq_behavior eq_value actual_behavior expected_behavior =
+  match actual_behavior, expected_behavior with
+  | Ok actual, Ok expected ->
+      eq_value actual expected (* value comparison *)
+  | Error actual, Error expected ->
+      actual = expected  (* exception comparison *)
+  | Ok _, Error _
+  | Error _, Ok _ ->
+      false
+
+let show_actual_behavior show_value behavior =
+  match behavior with
+  | Ok v ->
+      R.Text "produces the following result:" ::
+      R.Output (show_value v) ::
+      []
+  | Error e ->
+      R.Text "raises the following exception:" ::
+      R.Output (Printexc.to_string e) ::
+      []
+
+let show_expected_behavior show_value behavior =
+  match behavior with
+  | Ok v ->
+      R.Text "This is invalid. Producing the following result is valid:" ::
+      R.Output (show_value v) ::
+      []
+  | Error e ->
+      R.Text "This is invalid. Raising the following exception is valid:" ::
+      R.Output (Printexc.to_string e) ::
+      []
+
+let something_is_wrong =
+  R.Text "Something is wrong." ::
+  []
+
+let incorrect name =
+  R.Code name :: R.Text "is incorrect." ::
+  R.Break ::
+  []
+
+let black_box_compare
+  (* Value equality and display, used to compare and show results. *)
+  eq_value show_value
+  (* The beginning of the error message. Use [something_is_wrong] or [incorrect name]. *)
+  announcement
+  (* Expression display. *)
+  show_expr expr
+  (* Actual behavior and expected behavior. *)
+  actual_behavior
+  expected_behavior
+=
+  (* Allow [TODO] to escape and abort the whole test. *)
+  if actual_behavior = Error TODO then
+    raise TODO
+  else if not (eq_behavior eq_value actual_behavior expected_behavior) then
+    fail (
+      announcement @
+      R.Text "The following expression:" ::
+      R.Break ::
+      R.Code (show_expr expr) ::
+      R.Break ::
+      show_actual_behavior show_value actual_behavior @
+      show_expected_behavior show_value expected_behavior
+    )
+
+let test_value_1 name ty reference printx showy eqy tests =
+  grab ty name (fun candidate ->
+    protect (fun () ->
+      tests |> List.iter (fun x ->
+        let actual_behavior = T.result (fun () -> candidate x)
+        and expected_behavior = T.result (fun () -> reference x) in
+        let print_expr () =
+          apply name [ printx x ]
+            (* beware: [printx] must produce parentheses if necessary *)
+        in
+        black_box_compare
+          eqy showy
+          (incorrect name)
+          (wrap print_expr) ()
+          actual_behavior
+          expected_behavior
+      );
+      correct name
+    )
+  )
+
+let test_value_2 name ty reference printx1 printx2 showy eqy tests =
+  grab ty name (fun candidate ->
+    protect (fun () ->
+      tests |> List.iter (fun ((x1, x2) as x) ->
+        let actual_behavior = T.result (fun () -> candidate x1 x2)
+        and expected_behavior = T.result (fun () -> reference x1 x2) in
+        let print_expr () =
+          apply name [ printx1 x1; printx2 x2 ]
+            (* beware: [printx1] and [printx2] must produce parentheses
+               if necessary *)
+        in
+        black_box_compare
+          eqy showy
+          (incorrect name)
+          (wrap print_expr) ()
+          actual_behavior
+          expected_behavior
+      );
+      correct name
+    )
+  )
+
+let test_value_3 name ty reference printx1 printx2 printx3 showy eqy tests =
+  grab ty name (fun candidate ->
+    protect (fun () ->
+      tests |> List.iter (fun ((x1, x2, x3) as x) ->
+        let actual_behavior = T.result (fun () -> candidate x1 x2 x3)
+        and expected_behavior = T.result (fun () -> reference x1 x2 x3) in
+        let print_expr () =
+          apply name [ printx1 x1; printx2 x2; printx3 x3 ]
+            (* beware: [printx1], etc. must produce parentheses
+               if necessary *)
+        in
+        black_box_compare
+          eqy showy
+          (incorrect name)
+          (wrap print_expr) ()
+          actual_behavior
+          expected_behavior
+      );
+      correct name
+    )
+  )
+
+(* -------------------------------------------------------------------------- *)
+
+(* List-based enumerations. *)
+
+let flat_map f xss =
+  List.flatten (List.map f xss)
+
+(* [up i j] is the list of the integers of [i] included up to [j] excluded. *)
+
+(* [upk i j k] is [up i j @ k]. *)
+
+let rec upk i j k =
+  if i < j then
+    i :: upk (i + 1) j k
+  else
+    k
+
+let up i j =
+  upk i j []
+
+(* [pairs xs ys] is the list of all pairs [x, y] where [x] is drawn from [xs]
+   and [y] is drawn from [ys]. In other words, it is the Cartesian product of
+   the lists [xs] and [ys]. *)
+
+let pairs xs ys =
+  xs |> flat_map (fun x ->
+    ys |> flat_map (fun y ->
+      [x, y]
+    )
+  )
+
+(* [split n f] enumerates all manners of splitting [n] into [n1 + n2], where
+   [n1] and [n2] can be zero. For each such split, the enumeration [f n1 n2]
+   is produced. *)
+
+let split n f =
+  flat_map (fun n1 ->
+    let n2 = n - n1 in
+    f n1 n2
+  ) (up 0 (n+1))
+
+(* If [f i] is an enumeration, then [deepening f n] is the concatenation
+   of the enumerations [f 0, f 1, ... f n]. *)
+
+let deepening (f : int -> 'a list) (n : int) : 'a list =
+  flat_map f (up 0 (n+1))
+
+(* -------------------------------------------------------------------------- *)
+
+(* Printers. *)
+
+(* A printer for strings. *)
+
+let show_string s =
+  sprintf "\"%s\"" (String.escaped s)
+
+let print_string s =
+  utf8string (show_string s)
+
+(* A printer for integers. *)
+
+let print_int =
+  int
+
+let show_int i =
+  sprintf "%d" i
+
+(* A printer for characters. *)
+
+let show_char c =
+  sprintf "'%s'" (Char.escaped c)
+
+(* A printer for Booleans. *)
+
+let show_bool b =
+  if b then "true" else "false"
+
+let print_bool b =
+  utf8string (show_bool b)
+
+(* A printer for options. *)
+
+let print_option print = function
+  | None ->
+       utf8string "None"
+  | Some x ->
+       construct "Some" [ print x ]
+
+(* A printer for arrays. *)
+
+let print_array print_element a =
+  group (ocaml_array_brackets (concat (
+    a |> Array.map (fun x ->
+      print_element x ^^ semicolon ^^ break 1
+    ) |> Array.to_list
+  )))
+
+(* A printer for lists. *)
+
+let print_list print_element xs =
+  list (map print_element xs)
+
+let print_list_int =
+  print_list print_int
+
+let show_list_int =
+  wrap print_list_int
+
+let print_int_int (x, t) =
+  parens (
+    utf8format "(* value: *) %d, (* work: *) %d" x t
+  )
+
+let print_list_int_int =
+  print_list print_int_int
+
+let show_list_int_int =
+  wrap print_list_int_int
+
+(* -------------------------------------------------------------------------- *)
+
+(* A DSL for monadic computations. *)
+
+(* The syntax of pure expressions allows zero-ary operators (constants) of
+   type [int] and unary operators of type ['a -> bool] and binary operators of
+   type ['a -> 'a -> 'a]. Each operator is accompanied with its textual
+   appearance as a plain OCaml expression. *)
+
+(* In the type [('g, 'a) expr], ['g] is the type of every variable in scope,
+   and ['a] is the type of the expression. *)
+
+(* In the syntax of computations, we restrict the type of [CBind] so that
+   every intermediate computation has result type ['a] and (therefore) every
+   variable in scope has type ['a] as well. This removes the need for dealing
+   with heterogeneous environments (both at the type level and value level),
+   facilitates printing of computations, etc. *)
+
+(* We ask the student to implement [at_most_once] rather than [once] because
+   the former has a simpler type, which fits the restriction above. *)
+
+type (_, _) expr =
+  | EVar: int (* de Bruijn index *) -> ('g, 'g) expr
+  | EConst: int -> ('g, int) expr
+
+type fair =
+  bool
+    (* The fair variant of [choose] is [interleave]. *)
+    (* The fair variant of [>>=] is [>>-]. *)
+
+type 'a comp =
+  (* Combinators implemented by me. *)
+  | CDelay of 'a comp
+  | CTick of 'a comp
+  (* Core combinators. (Unfair variants.) (Question 1.) *)
+  | CRet of ('a, 'a) expr
+  | CBind of fair * 'a comp * 'a comp (* >>= *)
+  | CFail
+  | CChoose of fair * 'a comp * 'a comp
+  (* More combinators. (Fair variants.) (Questions 2-4.) *)
+  | CAtMostOnce of 'a comp
+
+(* Generators. *)
+
+module DSLGen = struct
+
+  open Feat
+
+  (* Integer expressions. *)
+
+  (* [n] is the number of variables in scope. Memoization takes place over the
+     pair [(n, s)], where [s] is the size parameter, which remains implicit. *)
+
+  let evar x = EVar x
+  let econst k = EConst k
+
+  let int_expr : int -> (int, int) expr enum =
+    fix2 (fun int_expr n ->
+      map evar (finite (up 0 n)) ++
+      map econst (finite [ 0; 1 ])
+    )
+
+  (* Commands. *)
+
+  let cret e = CRet e
+  let cbind (c1, c2) = CBind (false, c1, c2)
+  let cdelay c = CDelay c
+  let ctick c = CTick c
+  let cchoose (c1, c2) = CChoose (false, c1, c2)
+  let catmostonce c = CAtMostOnce c
+  let cfairbind (c1, c2) = CBind (true, c1, c2)
+  let cfairchoose (c1, c2) = CChoose (true, c1, c2)
+
+  let core comp n =
+    map cret (int_expr n) ++
+    just CFail ++
+    pay (
+      map cbind (comp n ** comp (n+1)) ++
+      map cdelay (comp n) ++
+      map cchoose (comp n ** comp n)
+    )
+
+  (* Depending on the question number (Question 1, 2, etc.) we use more
+     and more combinators. *)
+
+  let q1 : int -> int comp enum =
+    fix2 (fun comp n ->
+      core comp n
+    )
+
+  let q2 : int -> int comp enum =
+    fix2 (fun comp n ->
+      core comp n ++
+      pay (map catmostonce (comp n))
+    )
+
+  let q3 : int -> int comp enum =
+    fix2 (fun comp n ->
+      core comp n ++
+      pay (map catmostonce (comp n)) ++
+      pay (map cfairchoose (comp n ** comp n))
+    )
+
+  let q4 : int -> int comp enum =
+    fix2 (fun comp n ->
+      core comp n ++
+      pay (map catmostonce (comp n)) ++
+      pay (map cfairchoose (comp n ** comp n)) ++
+      pay (map cfairbind (comp n ** comp n))
+    )
+
+end
+
+(* Instrumenting a command with [tick] instructions. *)
+
+(* We could insert [tick]s everywhere, but our counter-examples are a
+   little more readable if we insert fewer ticks. *)
+
+let rec instrument c =
+  match c with
+  | CRet _
+  | CFail ->
+      (* Tick [return] and [fail]. *)
+      CTick c
+  | CBind (fair, c1, c2) ->
+      (* Do not tick [bind]. *)
+      CBind (fair, instrument c1, instrument c2)
+  | CDelay c ->
+      (* Do not tick [delay]. *)
+      CDelay (instrument c)
+  | CTick c ->
+      (* won't happen *)
+      assert false
+  | CChoose (fair, c1, c2) ->
+      (* Do not tick [choose]. *)
+      CChoose (fair, instrument c1, instrument c2)
+  | CAtMostOnce c ->
+      (* Do not tick [at_most_once]. *)
+      CAtMostOnce (instrument c)
+
+(* Printers. *)
+
+module DSLPrinter = struct
+
+  type senv =
+    int
+
+  let show_var senv x =
+    assert (0 <= x && x < senv);
+    (* Convert the de Bruijn index [x] to a de Bruijn level. *)
+    let x = senv - 1 - x in
+    (* Use a fixed conversion scheme. *)
+    assert (x < 26);
+    let c = Char.chr (Char.code 'a' + x) in
+    String.make 1 c
+
+  let print_var senv x =
+    utf8string (show_var senv x)
+
+  let rec print_atomic_expr : type g a . senv -> (g, a) expr -> document =
+    fun senv e ->
+      match e with
+      | EVar x ->
+          print_var senv x
+      | EConst k ->
+          print_int k
+      | _ ->
+          parens (print_expr senv e)
+
+  and print_expr : type g a . senv -> (g, a) expr -> document =
+    fun senv e ->
+      match e with
+      | EVar _ ->
+          print_atomic_expr senv e
+      | EConst _ ->
+          print_atomic_expr senv e
+
+  let rec print_atomic_comp senv c =
+    match c with
+    | CFail ->
+        utf8string "fail"
+    | _ ->
+        parens (print_comp senv c)
+
+  and print_tight_comp senv c =
+    match c with
+    | CFail ->
+        print_atomic_comp senv c
+    | CRet e ->
+        apply "return" [ print_atomic_expr senv e ]
+    | CDelay c ->
+        apply "delay" [ print_atomic_comp senv c ]
+    | CTick c ->
+        apply "tick" [ print_atomic_comp senv c ]
+    | CAtMostOnce c ->
+        apply "at_most_once" [ print_atomic_comp senv c ]
+    | CChoose (fair, c1, c2) ->
+        apply
+          (if fair then "interleave" else "choose")
+          [ print_atomic_comp senv c1; print_atomic_comp senv c2 ]
+    | _ ->
+        parens (print_comp senv c)
+
+  and print_comp senv c =
+    group begin match c with
+    | CBind (fair, c1, c2) ->
+        let op = if fair then ">>-" else ">>=" in
+        group (
+          print_tight_comp senv c1 ^^ break 1 ^^
+          utf8format "%s fun %s ->" op (show_var (senv+1) 0)
+        ) ^^ break 1 ^^
+        print_tight_comp (senv+1) c2
+    | _ ->
+        print_tight_comp senv c
+    end
+
+  let print_atomic_comp c =
+    print_atomic_comp 0 c
+
+  let to_list doc =
+    piped_apply "Seq.to_list" [ doc ]
+
+  let take depth doc =
+    piped_apply "Seq.take" [ print_int depth; doc ]
+
+  let sols doc =
+    apply "sols" [ doc ]
+
+  let snapshot doc =
+    apply "Seq.map" [ utf8string "snapshot"; doc ]
+
+  let print_comp_sols_take depth c =
+    to_list (take depth (sols (print_atomic_comp c)))
+
+  let show_comp_sols_take depth =
+    wrap (print_comp_sols_take depth)
+
+  let print_comp_sols_snapshot_take depth c =
+    to_list (take depth (snapshot (sols (print_atomic_comp c))))
+
+  let show_comp_sols_snapshot_take depth =
+    wrap (print_comp_sols_snapshot_take depth)
+
+end
+
+(* A DSL interpreter. *)
+
+(* An expression evaluator. *)
+
+(* This evaluator is parameterized over an implementation of the signature
+   [REQUIRED]. *)
+
+(* Because (I think) we can only grab the student's code at a monomorphic
+   type, we cannot require these functions to be polymorphic. We require
+   just the monomorphic instances that we need for our test. *)
+
+type mono =
+  int
+
+module type REQUIRED = sig
+  val return: mono -> mono m
+  val (>>=) : mono m -> (mono -> mono m) -> mono m
+  val fail: mono m
+  val choose: mono m -> mono m -> mono m
+  (* The following components are optional, as they appear in
+     Questions 2-4. *)
+  val at_most_once: (mono m -> mono m) option
+  val interleave: (mono m -> mono m -> mono m) option
+  val (>>-): (mono m -> (mono -> mono m) -> mono m) option
+end
+
+module S = struct
+  include Solution
+  let at_most_once = Some at_most_once
+  let interleave = Some interleave
+  let (>>-) = Some (>>-)
+end
+
+let solution =
+  (module S : REQUIRED)
+
+let project o =
+  match o with
+  | Some x -> x
+  | None   -> assert false
+
+module DSLInterpreter = struct
+
+  let rec eval_expr : type g a . g list -> (g, a) expr -> a =
+    fun env e ->
+      match e with
+      | EVar x ->
+          List.nth env x
+      | EConst k ->
+          k
+
+  let eval_comp required (env : mono list) (c : mono comp) : mono m =
+    let module R = (val required : REQUIRED) in
+    let open R in
+    let rec eval_comp env c =
+      match c with
+      | CRet e ->
+          return (eval_expr env e)
+      | CBind (fair, c1, c2) ->
+          let bind = if fair then project (>>-) else (>>=) in
+          bind
+            (eval_comp env c1)
+            (fun x1 -> eval_comp (x1 :: env) c2)
+      | CDelay c ->
+          delay (fun () -> eval_comp env c)
+      | CTick c ->
+          tick (eval_comp env c)
+      | CFail ->
+          fail
+      | CChoose (fair, c1, c2) ->
+          let plus = if fair then project interleave else choose in
+          plus (eval_comp env c1) (eval_comp env c2)
+      | CAtMostOnce c ->
+          let at_most_once = project at_most_once in
+          at_most_once (eval_comp env c)
+    in
+    eval_comp env c
+
+  let eval_comp required (c : mono comp) : mono m =
+    eval_comp required [] c
+
+end
+
+(* -------------------------------------------------------------------------- *)
+
+(* Our black-box grading machinery. *)
+
+(* In Question 1, we grade four construction functions: [return], [>>=],
+   [fail], [choose], observed through one observation function, [sols].
+   In Questions 2-4, we gradually add three more construction functions,
+   [at_most_once], [interleave], and [>>-]. The testing machinery is the
+   same. *)
+
+module P = DSLPrinter
+module I = DSLInterpreter
+
+(* In order to avoid trouble with infinite sequences, we compare and print
+   sequences only down to a certain [depth]. *)
+
+let depth =
+  20
+
+(* First, we test functional correctness. We generate a computation using the
+   constructor functions, and apply [sols] to it, yielding a sequence. We
+   truncate this sequence at depth [depth] and force its evaluation by turning
+   it into a list. Then, we check that this list of results is correct by
+   comparing against our solution. *)
+
+let test_correctness tests student sols =
+  tests |> List.iter (fun (c : mono comp) ->
+    let expected_behavior =
+      Ok (
+        I.eval_comp solution c
+        |> Solution.sols
+        |> Seq.take depth
+        |> Seq.to_list
+      )
+    in
+    let actual_behavior =
+      T.result (fun () ->
+        I.eval_comp student c
+        |> sols
+        |> Seq.take depth
+        |> Seq.to_list
+      )
+    in
+    black_box_compare
+      (=) show_list_int
+      something_is_wrong
+      (P.show_comp_sols_take depth) c
+      actual_behavior
+      expected_behavior
+  );
+  (* Success. *)
+  let points = 1 in
+  let msg =
+    sprintf "The code seems correct. Tested %d scenarios."
+      (List.length tests)
+  in
+  [ R.success points msg ]
+
+(* Second, we test that computations are performed on demand, that is, as late
+   as possible. That is, demanding the next result should force execution to
+   take place only as far as necessary in order to produce this result. To
+   check this, we instrument our test computations with [tick] instructions,
+   which increment the global counter [time], and decorate every result with
+   the time at which it is produced. (A call to [Seq.map snapshot] suffices
+   for this purpose.) We check that these times are correct by comparing
+   against our solution. *)
+
+let test_laziness tests student sols =
+  let tests = List.map instrument tests in
+  tests |> List.iter (fun (c : mono comp) ->
+    let expected_behavior =
+      Ok (
+        reset();
+        I.eval_comp solution c
+        |> Solution.sols
+        |> Seq.map snapshot
+        |> Seq.take depth |> Seq.to_list
+      )
+    in
+    let actual_behavior =
+      T.result (fun () ->
+        reset();
+        I.eval_comp student c
+        |> sols
+        |> Seq.map snapshot
+        |> Seq.take depth |> Seq.to_list
+      )
+    in
+    black_box_compare
+      (=) show_list_int_int
+      [ R.Text "Some computations take place too early." ]
+      (P.show_comp_sols_snapshot_take depth) c
+      actual_behavior
+      expected_behavior
+  );
+  (* Success. *)
+  let points = 1 in
+  let msg = "The code seems lazy." in
+  [ R.success points msg ]
+
+(* Combine the above two phases. *)
+
+let test_both tests student sols =
+  section "Functional correctness" (
+    protect (fun () ->
+      test_correctness tests student sols
+    )
+  ) -@> fun () ->
+  section "Laziness" (
+    protect (fun () ->
+      test_laziness tests student sols
+    )
+  )
+
+(* -------------------------------------------------------------------------- *)
+
+(* Question 1. *)
+
+(* Grading the core functions: [return], [>>=], [fail], [choose], [sols]. *)
+
+let grab_core k =
+  (* Grab the student's five basic functions. *)
+  grab [%ty: mono -> mono m] "return" (fun return ->
+  grab [%ty: mono m -> (mono -> mono m) -> mono m] ">>=" (fun (>>=) ->
+  grab [%ty: mono m] "fail" (fun fail ->
+  grab [%ty: mono m -> mono m -> mono m] "choose" (fun choose ->
+  grab [%ty: mono m -> mono Seq.t] "sols" (fun sols ->
+  let module S = struct
+    let return = return
+    let (>>=) = (>>=)
+    let fail = fail
+    let choose = choose
+    let at_most_once = None
+    let interleave = None
+    let (>>-) = None
+  end in
+  let student = (module S : REQUIRED) in
+  k student sols
+  )))))
+
+let test_core () =
+  section "Question 1" (
+    grab_core (fun student sols ->
+      (* Generate test cases. *)
+      let tests = Feat.sample 1000 4 (DSLGen.q1 0) in
+      (* Test. *)
+      test_both tests student sols
+    )
+  )
+
+(* -------------------------------------------------------------------------- *)
+
+(* Question 2. *)
+
+(* Grading [at_most_once]. *)
+
+let grab_at_most_once k =
+  grab_core (fun student sols ->
+  grab [%ty: mono m -> mono m] "at_most_once" (fun candidate ->
+  let module S = struct
+    include (val student : REQUIRED)
+    let at_most_once = Some candidate
+  end in
+  let student = (module S : REQUIRED) in
+  k student sols
+  ))
+
+let test_at_most_once () =
+  section "Question 2" (
+    grab_at_most_once (fun student sols ->
+      (* Generate test cases. *)
+      let tests = Feat.sample 1000 4 (DSLGen.q2 0) in
+      (* Test. *)
+      test_both tests student sols
+    )
+  )
+
+(* -------------------------------------------------------------------------- *)
+
+(* Question 3. *)
+
+(* Grading [interleave]. *)
+
+let grab_interleave k =
+  grab_at_most_once (fun student sols ->
+  grab [%ty: mono m -> mono m -> mono m] "interleave" (fun candidate ->
+  let module S = struct
+    include (val student : REQUIRED)
+    let interleave = Some candidate
+  end in
+  let student = (module S : REQUIRED) in
+  k student sols
+  ))
+
+let test_interleave () =
+  section "Question 3" (
+    grab_interleave (fun student sols ->
+      (* Generate test cases. *)
+      let tests = Feat.sample 1000 4 (DSLGen.q3 0) in
+      (* Test. *)
+      test_both tests student sols
+    )
+  )
+
+(* -------------------------------------------------------------------------- *)
+
+(* Question 4. *)
+
+(* Grading [>>-]. *)
+
+let grab_fair_bind k =
+  grab_interleave (fun student sols ->
+  grab [%ty: mono m -> (mono -> mono m) -> mono m] ">>-" (fun candidate ->
+  let module S = struct
+    include (val student : REQUIRED)
+    let (>>-) = Some candidate
+  end in
+  let student = (module S : REQUIRED) in
+  k student sols
+  ))
+
+let test_fair_bind () =
+  section "Question 4" (
+    grab_fair_bind (fun student sols ->
+      (* Generate test cases. *)
+      let tests = Feat.sample 3000 5 (DSLGen.q4 0) in
+      (* Test. *)
+      test_both tests student sols
+    )
+  )
+
+(* -------------------------------------------------------------------------- *)
+
+(* Main. *)
+
+let report () =
+  test_core() -@>
+  test_at_most_once -@>
+  test_interleave -@>
+  test_fair_bind -@>
+  fun () -> []
+
+let () =
+  T.set_result (T.ast_sanity_check code_ast report)

--- a/exercises/nondet_monad_cont/wrong/at_most_once_id.log
+++ b/exercises/nondet_monad_cont/wrong/at_most_once_id.log
@@ -1,0 +1,2 @@
+Learnocaml v.0.10 running.
+[ Loading the prelude. ][K[ Preparing the test environment. ][K[ Loading your code. ][K[ Loading the solution. ][K[ Preparing to launch the tests. ][K[ Launching the test bench. ][K.                              - Failure - 2 points

--- a/exercises/nondet_monad_cont/wrong/at_most_once_id.ml
+++ b/exercises/nondet_monad_cont/wrong/at_most_once_id.ml
@@ -1,0 +1,25 @@
+let return (x : 'a) : 'a m =
+  let compute s f = s x f in
+  { compute }
+
+let (>>=) (m1 : 'a m) (f2 : 'a -> 'b m) : 'b m =
+  let compute s f = m1.compute (fun x f' -> (f2 x).compute s f') f in
+  { compute }
+
+let fail : 'a m =
+  let compute s f = f() in
+  { compute }
+
+let choose (m1 : 'a m) (m2 : 'a m) : 'a m =
+  let compute s f = m1.compute s (fun () -> m2.compute s f) in
+  { compute }
+
+let sols (m : 'a m) : 'a Seq.t =
+  fun () ->
+    m.compute
+      (fun x f -> Seq.Cons (x, f))
+      (fun () -> Seq.Nil)
+
+let at_most_once (m : 'a m) : 'a m =
+  (* Basic attempt to cheat! *)
+  m

--- a/exercises/nondet_monad_cont/wrong/at_most_once_id.report.txt
+++ b/exercises/nondet_monad_cont/wrong/at_most_once_id.report.txt
@@ -1,0 +1,24 @@
+Question 1
+  Found [return] with compatible type.
+  Found [>>=] with compatible type.
+  Found [fail] with compatible type.
+  Found [choose] with compatible type.
+  Found [sols] with compatible type.
+  Functional correctness
+    Success 1: The code seems correct. Tested 2411 scenarios.
+  Laziness
+    Success 1: The code seems lazy.
+Question 2
+  Found [return] with compatible type.
+  Found [>>=] with compatible type.
+  Found [fail] with compatible type.
+  Found [choose] with compatible type.
+  Found [sols] with compatible type.
+  Found [at_most_once] with compatible type.
+  Functional correctness
+    Failure: Something is wrong. The following expression:
+      
+       | sols (at_most_once (choose (return 0) (return 0))) |> Seq.take 20
+       | |> Seq.to_list
+      produces the following result: [[0; 0]] This is invalid. Producing the
+      following result is valid: [[0]]

--- a/exercises/nondet_monad_cont/wrong/bind_fail.log
+++ b/exercises/nondet_monad_cont/wrong/bind_fail.log
@@ -1,0 +1,2 @@
+Learnocaml v.0.10 running.
+[ Loading the prelude. ][K[ Preparing the test environment. ][K[ Loading your code. ][K[ Loading the solution. ][K[ Preparing to launch the tests. ][K[ Launching the test bench. ][K.                              - Failure - 0 points

--- a/exercises/nondet_monad_cont/wrong/bind_fail.ml
+++ b/exercises/nondet_monad_cont/wrong/bind_fail.ml
@@ -1,0 +1,20 @@
+let return (x : 'a) : 'a m =
+  let compute s f = s x f in
+  { compute }
+
+let fail : 'a m =
+  let compute s f = f() in
+  { compute }
+
+let (>>=) (m1 : 'a m) (f2 : 'a -> 'b m) : 'b m =
+  fail (* wrong *)
+
+let choose (m1 : 'a m) (m2 : 'a m) : 'a m =
+  let compute s f = m1.compute s (fun () -> m2.compute s f) in
+  { compute }
+
+let sols (m : 'a m) : 'a Seq.t =
+  fun () ->
+    m.compute
+      (fun x f -> Seq.Cons (x, f))
+      (fun () -> Seq.Nil)

--- a/exercises/nondet_monad_cont/wrong/bind_fail.report.txt
+++ b/exercises/nondet_monad_cont/wrong/bind_fail.report.txt
@@ -1,0 +1,12 @@
+Question 1
+  Found [return] with compatible type.
+  Found [>>=] with compatible type.
+  Found [fail] with compatible type.
+  Found [choose] with compatible type.
+  Found [sols] with compatible type.
+  Functional correctness
+    Failure: Something is wrong. The following expression:
+      
+       | sols (return 0 >>= fun a -> return a) |> Seq.take 20 |> Seq.to_list
+      produces the following result: [[]] This is invalid. Producing the
+      following result is valid: [[0]]

--- a/exercises/nondet_monad_cont/wrong/bind_wrong_failure_cont.log
+++ b/exercises/nondet_monad_cont/wrong/bind_wrong_failure_cont.log
@@ -1,0 +1,2 @@
+Learnocaml v.0.10 running.
+[ Loading the prelude. ][K[ Preparing the test environment. ][K[ Loading your code. ][K[ Loading the solution. ][K[ Preparing to launch the tests. ][K[ Launching the test bench. ][K.                              - Failure - 0 points

--- a/exercises/nondet_monad_cont/wrong/bind_wrong_failure_cont.ml
+++ b/exercises/nondet_monad_cont/wrong/bind_wrong_failure_cont.ml
@@ -1,0 +1,23 @@
+let return (x : 'a) : 'a m =
+  let compute s f = s x f in
+  { compute }
+
+let (>>=) (m1 : 'a m) (f2 : 'a -> 'b m) : 'b m =
+  let compute s f =
+    m1.compute (fun x f' -> (f2 x).compute s f (* wrong: should be [f'] *)) f
+  in
+  { compute }
+
+let fail : 'a m =
+  let compute s f = f() in
+  { compute }
+
+let choose (m1 : 'a m) (m2 : 'a m) : 'a m =
+  let compute s f = m1.compute s (fun () -> m2.compute s f) in
+  { compute }
+
+let sols (m : 'a m) : 'a Seq.t =
+  fun () ->
+    m.compute
+      (fun x f -> Seq.Cons (x, f))
+      (fun () -> Seq.Nil)

--- a/exercises/nondet_monad_cont/wrong/bind_wrong_failure_cont.report.txt
+++ b/exercises/nondet_monad_cont/wrong/bind_wrong_failure_cont.report.txt
@@ -1,0 +1,14 @@
+Question 1
+  Found [return] with compatible type.
+  Found [>>=] with compatible type.
+  Found [fail] with compatible type.
+  Found [choose] with compatible type.
+  Found [sols] with compatible type.
+  Functional correctness
+    Failure: Something is wrong. The following expression:
+      
+       | sols (choose (return 0) (return 0) >>= fun a -> return a)
+       | |> Seq.take 20
+       | |> Seq.to_list
+      produces the following result: [[0]] This is invalid. Producing the
+      following result is valid: [[0; 0]]

--- a/exercises/nondet_monad_cont/wrong/choose_fail.log
+++ b/exercises/nondet_monad_cont/wrong/choose_fail.log
@@ -1,0 +1,2 @@
+Learnocaml v.0.10 running.
+[ Loading the prelude. ][K[ Preparing the test environment. ][K[ Loading your code. ][K[ Loading the solution. ][K[ Preparing to launch the tests. ][K[ Launching the test bench. ][K.                              - Failure - 0 points

--- a/exercises/nondet_monad_cont/wrong/choose_fail.ml
+++ b/exercises/nondet_monad_cont/wrong/choose_fail.ml
@@ -1,0 +1,65 @@
+let return (x : 'a) : 'a m =
+  let compute s f = s x f in
+  { compute }
+
+let (>>=) (m1 : 'a m) (f2 : 'a -> 'b m) : 'b m =
+  let compute s f = m1.compute (fun x f' -> (f2 x).compute s f') f in
+  { compute }
+
+let fail : 'a m =
+  let compute s f = f() in
+  { compute }
+
+let choose (m1 : 'a m) (m2 : 'a m) : 'a m =
+  fail (* wrong *)
+
+let sols (m : 'a m) : 'a Seq.t =
+  fun () ->
+    m.compute
+      (fun x f -> Seq.Cons (x, f))
+      (fun () -> Seq.Nil)
+
+(* The functions [reflect] and [msplit] witness an isomorphism between the
+   type ['a m] and the type [unit -> ('a * 'a m) option]. *)
+
+let reflect (o : unit -> ('a * 'a m) option) : 'a m =
+  delay (fun () ->
+    match o() with
+    | None ->
+        fail
+    | Some (x, m) ->
+        choose (return x) m
+  )
+
+let msplit (m : 'a m) : unit -> ('a * 'a m) option =
+  fun () ->
+    m.compute
+      (fun x f -> Some (x, reflect f))
+      (fun () -> None)
+
+let at_most_once (m : 'a m) : 'a m =
+    delay (fun () ->
+      match msplit m () with
+      | None ->
+          fail
+      | Some (x, _) ->
+          return x
+    )
+
+let rec interleave (m1 : 'a m) (m2 : 'a m) : 'a m =
+    delay (fun () ->
+      match msplit m1 () with
+      | None ->
+          m2
+      | Some (x1, m1) ->
+          choose (return x1) (interleave m2 m1)
+    )
+
+let rec (>>-) (m1 : 'a m) (f2 : 'a -> 'b m) : 'b m =
+  delay (fun () ->
+    match msplit m1 () with
+    | None ->
+        fail
+    | Some (x1, m1) ->
+        interleave (f2 x1) (m1 >>- f2)
+  )

--- a/exercises/nondet_monad_cont/wrong/choose_fail.report.txt
+++ b/exercises/nondet_monad_cont/wrong/choose_fail.report.txt
@@ -1,0 +1,12 @@
+Question 1
+  Found [return] with compatible type.
+  Found [>>=] with compatible type.
+  Found [fail] with compatible type.
+  Found [choose] with compatible type.
+  Found [sols] with compatible type.
+  Functional correctness
+    Failure: Something is wrong. The following expression:
+      
+       | sols (choose (return 0) (return 0)) |> Seq.take 20 |> Seq.to_list
+      produces the following result: [[]] This is invalid. Producing the
+      following result is valid: [[0; 0]]

--- a/exercises/nondet_monad_cont/wrong/choose_left.log
+++ b/exercises/nondet_monad_cont/wrong/choose_left.log
@@ -1,0 +1,2 @@
+Learnocaml v.0.10 running.
+[ Loading the prelude. ][K[ Preparing the test environment. ][K[ Loading your code. ][K[ Loading the solution. ][K[ Preparing to launch the tests. ][K[ Launching the test bench. ][K.                              - Failure - 0 points

--- a/exercises/nondet_monad_cont/wrong/choose_left.ml
+++ b/exercises/nondet_monad_cont/wrong/choose_left.ml
@@ -1,0 +1,65 @@
+let return (x : 'a) : 'a m =
+  let compute s f = s x f in
+  { compute }
+
+let (>>=) (m1 : 'a m) (f2 : 'a -> 'b m) : 'b m =
+  let compute s f = m1.compute (fun x f' -> (f2 x).compute s f') f in
+  { compute }
+
+let fail : 'a m =
+  let compute s f = f() in
+  { compute }
+
+let choose (m1 : 'a m) (m2 : 'a m) : 'a m =
+  m1 (* wrong *)
+
+let sols (m : 'a m) : 'a Seq.t =
+  fun () ->
+    m.compute
+      (fun x f -> Seq.Cons (x, f))
+      (fun () -> Seq.Nil)
+
+(* The functions [reflect] and [msplit] witness an isomorphism between the
+   type ['a m] and the type [unit -> ('a * 'a m) option]. *)
+
+let reflect (o : unit -> ('a * 'a m) option) : 'a m =
+  delay (fun () ->
+    match o() with
+    | None ->
+        fail
+    | Some (x, m) ->
+        choose (return x) m
+  )
+
+let msplit (m : 'a m) : unit -> ('a * 'a m) option =
+  fun () ->
+    m.compute
+      (fun x f -> Some (x, reflect f))
+      (fun () -> None)
+
+let at_most_once (m : 'a m) : 'a m =
+    delay (fun () ->
+      match msplit m () with
+      | None ->
+          fail
+      | Some (x, _) ->
+          return x
+    )
+
+let rec interleave (m1 : 'a m) (m2 : 'a m) : 'a m =
+    delay (fun () ->
+      match msplit m1 () with
+      | None ->
+          m2
+      | Some (x1, m1) ->
+          choose (return x1) (interleave m2 m1)
+    )
+
+let rec (>>-) (m1 : 'a m) (f2 : 'a -> 'b m) : 'b m =
+  delay (fun () ->
+    match msplit m1 () with
+    | None ->
+        fail
+    | Some (x1, m1) ->
+        interleave (f2 x1) (m1 >>- f2)
+  )

--- a/exercises/nondet_monad_cont/wrong/choose_left.report.txt
+++ b/exercises/nondet_monad_cont/wrong/choose_left.report.txt
@@ -1,0 +1,12 @@
+Question 1
+  Found [return] with compatible type.
+  Found [>>=] with compatible type.
+  Found [fail] with compatible type.
+  Found [choose] with compatible type.
+  Found [sols] with compatible type.
+  Functional correctness
+    Failure: Something is wrong. The following expression:
+      
+       | sols (choose (return 0) (return 0)) |> Seq.take 20 |> Seq.to_list
+      produces the following result: [[0]] This is invalid. Producing the
+      following result is valid: [[0; 0]]

--- a/exercises/nondet_monad_cont/wrong/choose_reversed.log
+++ b/exercises/nondet_monad_cont/wrong/choose_reversed.log
@@ -1,0 +1,2 @@
+Learnocaml v.0.10 running.
+[ Loading the prelude. ][K[ Preparing the test environment. ][K[ Loading your code. ][K[ Loading the solution. ][K[ Preparing to launch the tests. ][K[ Launching the test bench. ][K.                              - Failure - 0 points

--- a/exercises/nondet_monad_cont/wrong/choose_reversed.ml
+++ b/exercises/nondet_monad_cont/wrong/choose_reversed.ml
@@ -1,0 +1,69 @@
+let return (x : 'a) : 'a m =
+  let compute s f = s x f in
+  { compute }
+
+let (>>=) (m1 : 'a m) (f2 : 'a -> 'b m) : 'b m =
+  let compute s f = m1.compute (fun x f' -> (f2 x).compute s f') f in
+  { compute }
+
+let fail : 'a m =
+  let compute s f = f() in
+  { compute }
+
+let choose (m1 : 'a m) (m2 : 'a m) : 'a m =
+  let compute s f = m1.compute s (fun () -> m2.compute s f) in
+  { compute }
+
+let choose m1 m2 =
+  choose m2 m1 (* wrong *)
+
+let sols (m : 'a m) : 'a Seq.t =
+  fun () ->
+    m.compute
+      (fun x f -> Seq.Cons (x, f))
+      (fun () -> Seq.Nil)
+
+(* The functions [reflect] and [msplit] witness an isomorphism between the
+   type ['a m] and the type [unit -> ('a * 'a m) option]. *)
+
+let reflect (o : unit -> ('a * 'a m) option) : 'a m =
+  delay (fun () ->
+    match o() with
+    | None ->
+        fail
+    | Some (x, m) ->
+        choose (return x) m
+  )
+
+let msplit (m : 'a m) : unit -> ('a * 'a m) option =
+  fun () ->
+    m.compute
+      (fun x f -> Some (x, reflect f))
+      (fun () -> None)
+
+let at_most_once (m : 'a m) : 'a m =
+    delay (fun () ->
+      match msplit m () with
+      | None ->
+          fail
+      | Some (x, _) ->
+          return x
+    )
+
+let rec interleave (m1 : 'a m) (m2 : 'a m) : 'a m =
+    delay (fun () ->
+      match msplit m1 () with
+      | None ->
+          m2
+      | Some (x1, m1) ->
+          choose (return x1) (interleave m2 m1)
+    )
+
+let rec (>>-) (m1 : 'a m) (f2 : 'a -> 'b m) : 'b m =
+  delay (fun () ->
+    match msplit m1 () with
+    | None ->
+        fail
+    | Some (x1, m1) ->
+        interleave (f2 x1) (m1 >>- f2)
+  )

--- a/exercises/nondet_monad_cont/wrong/choose_reversed.report.txt
+++ b/exercises/nondet_monad_cont/wrong/choose_reversed.report.txt
@@ -1,0 +1,12 @@
+Question 1
+  Found [return] with compatible type.
+  Found [>>=] with compatible type.
+  Found [fail] with compatible type.
+  Found [choose] with compatible type.
+  Found [sols] with compatible type.
+  Functional correctness
+    Failure: Something is wrong. The following expression:
+      
+       | sols (choose (return 0) (return 1)) |> Seq.take 20 |> Seq.to_list
+      produces the following result: [[1; 0]] This is invalid. Producing the
+      following result is valid: [[0; 1]]

--- a/exercises/nondet_monad_cont/wrong/choose_right.log
+++ b/exercises/nondet_monad_cont/wrong/choose_right.log
@@ -1,0 +1,2 @@
+Learnocaml v.0.10 running.
+[ Loading the prelude. ][K[ Preparing the test environment. ][K[ Loading your code. ][K[ Loading the solution. ][K[ Preparing to launch the tests. ][K[ Launching the test bench. ][K.                              - Failure - 0 points

--- a/exercises/nondet_monad_cont/wrong/choose_right.ml
+++ b/exercises/nondet_monad_cont/wrong/choose_right.ml
@@ -1,0 +1,65 @@
+let return (x : 'a) : 'a m =
+  let compute s f = s x f in
+  { compute }
+
+let (>>=) (m1 : 'a m) (f2 : 'a -> 'b m) : 'b m =
+  let compute s f = m1.compute (fun x f' -> (f2 x).compute s f') f in
+  { compute }
+
+let fail : 'a m =
+  let compute s f = f() in
+  { compute }
+
+let choose (m1 : 'a m) (m2 : 'a m) : 'a m =
+  m2 (* wrong *)
+
+let sols (m : 'a m) : 'a Seq.t =
+  fun () ->
+    m.compute
+      (fun x f -> Seq.Cons (x, f))
+      (fun () -> Seq.Nil)
+
+(* The functions [reflect] and [msplit] witness an isomorphism between the
+   type ['a m] and the type [unit -> ('a * 'a m) option]. *)
+
+let reflect (o : unit -> ('a * 'a m) option) : 'a m =
+  delay (fun () ->
+    match o() with
+    | None ->
+        fail
+    | Some (x, m) ->
+        choose (return x) m
+  )
+
+let msplit (m : 'a m) : unit -> ('a * 'a m) option =
+  fun () ->
+    m.compute
+      (fun x f -> Some (x, reflect f))
+      (fun () -> None)
+
+let at_most_once (m : 'a m) : 'a m =
+    delay (fun () ->
+      match msplit m () with
+      | None ->
+          fail
+      | Some (x, _) ->
+          return x
+    )
+
+let rec interleave (m1 : 'a m) (m2 : 'a m) : 'a m =
+    delay (fun () ->
+      match msplit m1 () with
+      | None ->
+          m2
+      | Some (x1, m1) ->
+          choose (return x1) (interleave m2 m1)
+    )
+
+let rec (>>-) (m1 : 'a m) (f2 : 'a -> 'b m) : 'b m =
+  delay (fun () ->
+    match msplit m1 () with
+    | None ->
+        fail
+    | Some (x1, m1) ->
+        interleave (f2 x1) (m1 >>- f2)
+  )

--- a/exercises/nondet_monad_cont/wrong/choose_right.report.txt
+++ b/exercises/nondet_monad_cont/wrong/choose_right.report.txt
@@ -1,0 +1,12 @@
+Question 1
+  Found [return] with compatible type.
+  Found [>>=] with compatible type.
+  Found [fail] with compatible type.
+  Found [choose] with compatible type.
+  Found [sols] with compatible type.
+  Functional correctness
+    Failure: Something is wrong. The following expression:
+      
+       | sols (choose (return 0) (return 0)) |> Seq.take 20 |> Seq.to_list
+      produces the following result: [[0]] This is invalid. Producing the
+      following result is valid: [[0; 0]]

--- a/exercises/nondet_monad_cont/wrong/delayed_failure.log
+++ b/exercises/nondet_monad_cont/wrong/delayed_failure.log
@@ -1,0 +1,2 @@
+Learnocaml v.0.10 running.
+[ Loading the prelude. ][K[ Preparing the test environment. ][K[ Loading your code. ][K[ Loading the solution. ][K[ Preparing to launch the tests. ][K[ Launching the test bench. ][K.                              - Failure - 0 points

--- a/exercises/nondet_monad_cont/wrong/delayed_failure.ml
+++ b/exercises/nondet_monad_cont/wrong/delayed_failure.ml
@@ -1,0 +1,24 @@
+exception Gotcha
+
+let gotcha : 'a m =
+  delay (fun () -> raise Gotcha)
+  (* wrong: this fails when the sequence is forced --
+     even though it appears to succeed at construction time. *)
+
+let return (x : 'a) : 'a m =
+  gotcha
+
+let (>>=) (m1 : 'a m) (f2 : 'a -> 'b m) : 'b m =
+  gotcha
+
+let fail : 'a m =
+  gotcha
+
+let choose (m1 : 'a m) (m2 : 'a m) : 'a m =
+  gotcha
+
+let sols (m : 'a m) : 'a Seq.t =
+  fun () ->
+    m.compute
+      (fun x f -> Seq.Cons (x, f))
+      (fun () -> Seq.Nil)

--- a/exercises/nondet_monad_cont/wrong/delayed_failure.report.txt
+++ b/exercises/nondet_monad_cont/wrong/delayed_failure.report.txt
@@ -1,0 +1,12 @@
+Question 1
+  Found [return] with compatible type.
+  Found [>>=] with compatible type.
+  Found [fail] with compatible type.
+  Found [choose] with compatible type.
+  Found [sols] with compatible type.
+  Functional correctness
+    Failure: Something is wrong. The following expression:
+      
+       | sols (return 0) |> Seq.take 20 |> Seq.to_list
+      raises the following exception: [Code.Gotcha] This is invalid.
+      Producing the following result is valid: [[0]]

--- a/exercises/nondet_monad_cont/wrong/early_at_most_once.log
+++ b/exercises/nondet_monad_cont/wrong/early_at_most_once.log
@@ -1,0 +1,2 @@
+Learnocaml v.0.10 running.
+[ Loading the prelude. ][K[ Preparing the test environment. ][K[ Loading your code. ][K[ Loading the solution. ][K[ Preparing to launch the tests. ][K[ Launching the test bench. ][K.                              - Failure - 3 points

--- a/exercises/nondet_monad_cont/wrong/early_at_most_once.ml
+++ b/exercises/nondet_monad_cont/wrong/early_at_most_once.ml
@@ -1,0 +1,65 @@
+let return (x : 'a) : 'a m =
+  let compute s f = s x f in
+  { compute }
+
+let (>>=) (m1 : 'a m) (f2 : 'a -> 'b m) : 'b m =
+  let compute s f = m1.compute (fun x f' -> (f2 x).compute s f') f in
+  { compute }
+
+let fail : 'a m =
+  let compute s f = f() in
+  { compute }
+
+let choose (m1 : 'a m) (m2 : 'a m) : 'a m =
+  let compute s f = m1.compute s (fun () -> m2.compute s f) in
+  { compute }
+
+let sols (m : 'a m) : 'a Seq.t =
+  fun () ->
+    m.compute
+      (fun x f -> Seq.Cons (x, f))
+      (fun () -> Seq.Nil)
+
+(* The functions [reflect] and [msplit] witness an isomorphism between the
+   type ['a m] and the type [unit -> ('a * 'a m) option]. *)
+
+let reflect (o : unit -> ('a * 'a m) option) : 'a m =
+  delay (fun () ->
+    match o() with
+    | None ->
+        fail
+    | Some (x, m) ->
+        choose (return x) m
+  )
+
+let msplit (m : 'a m) : unit -> ('a * 'a m) option =
+  fun () ->
+    m.compute
+      (fun x f -> Some (x, reflect f))
+      (fun () -> None)
+
+let at_most_once (m : 'a m) : 'a m =
+  (* wrong: functionally correct, but too eager *)
+  match msplit m () with
+  | None ->
+      fail
+  | Some (x, _) ->
+      return x
+
+let rec interleave (m1 : 'a m) (m2 : 'a m) : 'a m =
+    delay (fun () ->
+      match msplit m1 () with
+      | None ->
+          m2
+      | Some (x1, m1) ->
+          choose (return x1) (interleave m2 m1)
+    )
+
+let rec (>>-) (m1 : 'a m) (f2 : 'a -> 'b m) : 'b m =
+  delay (fun () ->
+    match msplit m1 () with
+    | None ->
+        fail
+    | Some (x1, m1) ->
+        interleave (f2 x1) (m1 >>- f2)
+  )

--- a/exercises/nondet_monad_cont/wrong/early_at_most_once.report.txt
+++ b/exercises/nondet_monad_cont/wrong/early_at_most_once.report.txt
@@ -1,0 +1,32 @@
+Question 1
+  Found [return] with compatible type.
+  Found [>>=] with compatible type.
+  Found [fail] with compatible type.
+  Found [choose] with compatible type.
+  Found [sols] with compatible type.
+  Functional correctness
+    Success 1: The code seems correct. Tested 2411 scenarios.
+  Laziness
+    Success 1: The code seems lazy.
+Question 2
+  Found [return] with compatible type.
+  Found [>>=] with compatible type.
+  Found [fail] with compatible type.
+  Found [choose] with compatible type.
+  Found [sols] with compatible type.
+  Found [at_most_once] with compatible type.
+  Functional correctness
+    Success 1: The code seems correct. Tested 2486 scenarios.
+  Laziness
+    Failure: Some computations take place too early. The following
+             expression:
+      
+       | Seq.map snapshot sols (
+       |   choose (tick (return 0)) (at_most_once (tick (return 0)))
+       | )
+       | |> Seq.take 20
+       | |> Seq.to_list
+      produces the following result: [[((* value: *) 0, (* work: *) 2); ((*
+      value: *) 0, (* work: *) 2)]] This is invalid. Producing the following
+      result is valid: [[((* value: *) 0, (* work: *) 1); ((* value: *) 0, (*
+      work: *) 2)]]

--- a/exercises/nondet_monad_cont/wrong/early_bind.log
+++ b/exercises/nondet_monad_cont/wrong/early_bind.log
@@ -1,0 +1,2 @@
+Learnocaml v.0.10 running.
+[ Loading the prelude. ][K[ Preparing the test environment. ][K[ Loading your code. ][K[ Loading the solution. ][K[ Preparing to launch the tests. ][K[ Launching the test bench. ][K.                              - Failure - 1 points

--- a/exercises/nondet_monad_cont/wrong/early_bind.ml
+++ b/exercises/nondet_monad_cont/wrong/early_bind.ml
@@ -1,0 +1,36 @@
+let return (x : 'a) : 'a m =
+  let compute s f = s x f in
+  { compute }
+
+let (>>=) (m1 : 'a m) (f2 : 'a -> 'b m) : 'b m =
+  let compute s f = m1.compute (fun x f' -> (f2 x).compute s f') f in
+  { compute }
+
+let fail : 'a m =
+  let compute s f = f() in
+  { compute }
+
+let choose (m1 : 'a m) (m2 : 'a m) : 'a m =
+  let compute s f = m1.compute s (fun () -> m2.compute s f) in
+  { compute }
+
+let sols (m : 'a m) : 'a Seq.t =
+  fun () ->
+    m.compute
+      (fun x f -> Seq.Cons (x, f))
+      (fun () -> Seq.Nil)
+
+let rec eager_of_seq (xs : 'a Seq.t) : 'a m =
+  match xs() with
+  | Seq.Nil ->
+      fail
+  | Seq.Cons (x, xs) ->
+      choose (return x) (eager_of_seq xs)
+
+let force (m : 'a m) : 'a m =
+  eager_of_seq (sols m)
+
+(* Sabotage bind. *)
+
+let (>>=) m1 f2 =
+  force (m1 >>= f2)

--- a/exercises/nondet_monad_cont/wrong/early_bind.report.txt
+++ b/exercises/nondet_monad_cont/wrong/early_bind.report.txt
@@ -1,0 +1,22 @@
+Question 1
+  Found [return] with compatible type.
+  Found [>>=] with compatible type.
+  Found [fail] with compatible type.
+  Found [choose] with compatible type.
+  Found [sols] with compatible type.
+  Functional correctness
+    Success 1: The code seems correct. Tested 2411 scenarios.
+  Laziness
+    Failure: Some computations take place too early. The following
+             expression:
+      
+       | Seq.map snapshot sols (
+       |   tick (return 0) >>= fun a ->
+       |   choose (tick (return a)) (tick (return a))
+       | )
+       | |> Seq.take 20
+       | |> Seq.to_list
+      produces the following result: [[((* value: *) 0, (* work: *) 3); ((*
+      value: *) 0, (* work: *) 3)]] This is invalid. Producing the following
+      result is valid: [[((* value: *) 0, (* work: *) 2); ((* value: *) 0, (*
+      work: *) 3)]]

--- a/exercises/nondet_monad_cont/wrong/early_choose.log
+++ b/exercises/nondet_monad_cont/wrong/early_choose.log
@@ -1,0 +1,2 @@
+Learnocaml v.0.10 running.
+[ Loading the prelude. ][K[ Preparing the test environment. ][K[ Loading your code. ][K[ Loading the solution. ][K[ Preparing to launch the tests. ][K[ Launching the test bench. ][K.                              - Failure - 1 points

--- a/exercises/nondet_monad_cont/wrong/early_choose.ml
+++ b/exercises/nondet_monad_cont/wrong/early_choose.ml
@@ -1,0 +1,36 @@
+let return (x : 'a) : 'a m =
+  let compute s f = s x f in
+  { compute }
+
+let (>>=) (m1 : 'a m) (f2 : 'a -> 'b m) : 'b m =
+  let compute s f = m1.compute (fun x f' -> (f2 x).compute s f') f in
+  { compute }
+
+let fail : 'a m =
+  let compute s f = f() in
+  { compute }
+
+let choose (m1 : 'a m) (m2 : 'a m) : 'a m =
+  let compute s f = m1.compute s (fun () -> m2.compute s f) in
+  { compute }
+
+let sols (m : 'a m) : 'a Seq.t =
+  fun () ->
+    m.compute
+      (fun x f -> Seq.Cons (x, f))
+      (fun () -> Seq.Nil)
+
+let rec eager_of_seq (xs : 'a Seq.t) : 'a m =
+  match xs() with
+  | Seq.Nil ->
+      fail
+  | Seq.Cons (x, xs) ->
+      choose (return x) (eager_of_seq xs)
+
+let force (m : 'a m) : 'a m =
+  eager_of_seq (sols m)
+
+(* Sabotage choose. *)
+
+let choose m1 m2 =
+  choose (force m1) m2

--- a/exercises/nondet_monad_cont/wrong/early_choose.report.txt
+++ b/exercises/nondet_monad_cont/wrong/early_choose.report.txt
@@ -1,0 +1,44 @@
+Question 1
+  Found [return] with compatible type.
+  Found [>>=] with compatible type.
+  Found [fail] with compatible type.
+  Found [choose] with compatible type.
+  Found [sols] with compatible type.
+  Functional correctness
+    Success 1: The code seems correct. Tested 2411 scenarios.
+  Laziness
+    Failure: Some computations take place too early. The following
+             expression:
+      
+       | Seq.map snapshot sols (
+       |   choose (
+       |     tick (return 0)
+       |   ) (
+       |     choose (tick (return 0)) (tick (return 0))
+       |   )
+       | )
+       | |> Seq.take 20
+       | |> Seq.to_list
+      produces the following result:
+       | [
+       |   (
+       |     (* value: *) 0, (* work: *) 2
+       |   );
+       |   (
+       |     (* value: *) 0, (* work: *) 2
+       |   );
+       |   (
+       |     (* value: *) 0, (* work: *) 3
+       |   )
+       | ]This is invalid. Producing the following result is valid:
+       | [
+       |   (
+       |     (* value: *) 0, (* work: *) 1
+       |   );
+       |   (
+       |     (* value: *) 0, (* work: *) 2
+       |   );
+       |   (
+       |     (* value: *) 0, (* work: *) 3
+       |   )
+       | ]

--- a/exercises/nondet_monad_cont/wrong/early_choose_right.log
+++ b/exercises/nondet_monad_cont/wrong/early_choose_right.log
@@ -1,0 +1,2 @@
+Learnocaml v.0.10 running.
+[ Loading the prelude. ][K[ Preparing the test environment. ][K[ Loading your code. ][K[ Loading the solution. ][K[ Preparing to launch the tests. ][K[ Launching the test bench. ][K.                              - Failure - 1 points

--- a/exercises/nondet_monad_cont/wrong/early_choose_right.ml
+++ b/exercises/nondet_monad_cont/wrong/early_choose_right.ml
@@ -1,0 +1,36 @@
+let return (x : 'a) : 'a m =
+  let compute s f = s x f in
+  { compute }
+
+let (>>=) (m1 : 'a m) (f2 : 'a -> 'b m) : 'b m =
+  let compute s f = m1.compute (fun x f' -> (f2 x).compute s f') f in
+  { compute }
+
+let fail : 'a m =
+  let compute s f = f() in
+  { compute }
+
+let choose (m1 : 'a m) (m2 : 'a m) : 'a m =
+  let compute s f = m1.compute s (fun () -> m2.compute s f) in
+  { compute }
+
+let sols (m : 'a m) : 'a Seq.t =
+  fun () ->
+    m.compute
+      (fun x f -> Seq.Cons (x, f))
+      (fun () -> Seq.Nil)
+
+let rec eager_of_seq (xs : 'a Seq.t) : 'a m =
+  match xs() with
+  | Seq.Nil ->
+      fail
+  | Seq.Cons (x, xs) ->
+      choose (return x) (eager_of_seq xs)
+
+let force (m : 'a m) : 'a m =
+  eager_of_seq (sols m)
+
+(* Sabotage choose. *)
+
+let choose m1 m2 =
+  choose m1 (force m2)

--- a/exercises/nondet_monad_cont/wrong/early_choose_right.report.txt
+++ b/exercises/nondet_monad_cont/wrong/early_choose_right.report.txt
@@ -1,0 +1,19 @@
+Question 1
+  Found [return] with compatible type.
+  Found [>>=] with compatible type.
+  Found [fail] with compatible type.
+  Found [choose] with compatible type.
+  Found [sols] with compatible type.
+  Functional correctness
+    Success 1: The code seems correct. Tested 2411 scenarios.
+  Laziness
+    Failure: Some computations take place too early. The following
+             expression:
+      
+       | Seq.map snapshot sols (choose (tick (return 0)) (tick (return 0)))
+       | |> Seq.take 20
+       | |> Seq.to_list
+      produces the following result: [[((* value: *) 0, (* work: *) 2); ((*
+      value: *) 0, (* work: *) 2)]] This is invalid. Producing the following
+      result is valid: [[((* value: *) 0, (* work: *) 1); ((* value: *) 0, (*
+      work: *) 2)]]

--- a/exercises/nondet_monad_cont/wrong/early_fair_bind.log
+++ b/exercises/nondet_monad_cont/wrong/early_fair_bind.log
@@ -1,0 +1,2 @@
+Learnocaml v.0.10 running.
+[ Loading the prelude. ][K[ Preparing the test environment. ][K[ Loading your code. ][K[ Loading the solution. ][K[ Preparing to launch the tests. ][K[ Launching the test bench. ][K.                              - Failure - 7 points

--- a/exercises/nondet_monad_cont/wrong/early_fair_bind.ml
+++ b/exercises/nondet_monad_cont/wrong/early_fair_bind.ml
@@ -1,0 +1,65 @@
+let return (x : 'a) : 'a m =
+  let compute s f = s x f in
+  { compute }
+
+let (>>=) (m1 : 'a m) (f2 : 'a -> 'b m) : 'b m =
+  let compute s f = m1.compute (fun x f' -> (f2 x).compute s f') f in
+  { compute }
+
+let fail : 'a m =
+  let compute s f = f() in
+  { compute }
+
+let choose (m1 : 'a m) (m2 : 'a m) : 'a m =
+  let compute s f = m1.compute s (fun () -> m2.compute s f) in
+  { compute }
+
+let sols (m : 'a m) : 'a Seq.t =
+  fun () ->
+    m.compute
+      (fun x f -> Seq.Cons (x, f))
+      (fun () -> Seq.Nil)
+
+(* The functions [reflect] and [msplit] witness an isomorphism between the
+   type ['a m] and the type [unit -> ('a * 'a m) option]. *)
+
+let reflect (o : unit -> ('a * 'a m) option) : 'a m =
+  delay (fun () ->
+    match o() with
+    | None ->
+        fail
+    | Some (x, m) ->
+        choose (return x) m
+  )
+
+let msplit (m : 'a m) : unit -> ('a * 'a m) option =
+  fun () ->
+    m.compute
+      (fun x f -> Some (x, reflect f))
+      (fun () -> None)
+
+let at_most_once (m : 'a m) : 'a m =
+  delay (fun () ->
+    match msplit m () with
+    | None ->
+        fail
+    | Some (x, _) ->
+        return x
+  )
+
+let rec interleave (m1 : 'a m) (m2 : 'a m) : 'a m =
+  delay (fun () ->
+    match msplit m1 () with
+    | None ->
+        m2
+    | Some (x1, m1) ->
+        choose (return x1) (interleave m2 m1)
+  )
+
+let rec (>>-) (m1 : 'a m) (f2 : 'a -> 'b m) : 'b m =
+  (* wrong: missing [delay] *)
+  match msplit m1 () with
+  | None ->
+      fail
+  | Some (x1, m1) ->
+      interleave (f2 x1) (m1 >>- f2)

--- a/exercises/nondet_monad_cont/wrong/early_fair_bind.report.txt
+++ b/exercises/nondet_monad_cont/wrong/early_fair_bind.report.txt
@@ -1,0 +1,61 @@
+Question 1
+  Found [return] with compatible type.
+  Found [>>=] with compatible type.
+  Found [fail] with compatible type.
+  Found [choose] with compatible type.
+  Found [sols] with compatible type.
+  Functional correctness
+    Success 1: The code seems correct. Tested 2411 scenarios.
+  Laziness
+    Success 1: The code seems lazy.
+Question 2
+  Found [return] with compatible type.
+  Found [>>=] with compatible type.
+  Found [fail] with compatible type.
+  Found [choose] with compatible type.
+  Found [sols] with compatible type.
+  Found [at_most_once] with compatible type.
+  Functional correctness
+    Success 1: The code seems correct. Tested 2486 scenarios.
+  Laziness
+    Success 1: The code seems lazy.
+Question 3
+  Found [return] with compatible type.
+  Found [>>=] with compatible type.
+  Found [fail] with compatible type.
+  Found [choose] with compatible type.
+  Found [sols] with compatible type.
+  Found [at_most_once] with compatible type.
+  Found [interleave] with compatible type.
+  Functional correctness
+    Success 1: The code seems correct. Tested 2867 scenarios.
+  Laziness
+    Success 1: The code seems lazy.
+Question 4
+  Found [return] with compatible type.
+  Found [>>=] with compatible type.
+  Found [fail] with compatible type.
+  Found [choose] with compatible type.
+  Found [sols] with compatible type.
+  Found [at_most_once] with compatible type.
+  Found [interleave] with compatible type.
+  Found [>>-] with compatible type.
+  Functional correctness
+    Success 1: The code seems correct. Tested 10356 scenarios.
+  Laziness
+    Failure: Some computations take place too early. The following
+             expression:
+      
+       | Seq.map snapshot sols (
+       |   choose (
+       |     tick (return 0)
+       |   ) (
+       |     tick (return 0) >>- fun a -> tick (return 0)
+       |   )
+       | )
+       | |> Seq.take 20
+       | |> Seq.to_list
+      produces the following result: [[((* value: *) 0, (* work: *) 2); ((*
+      value: *) 0, (* work: *) 3)]] This is invalid. Producing the following
+      result is valid: [[((* value: *) 0, (* work: *) 1); ((* value: *) 0, (*
+      work: *) 3)]]

--- a/exercises/nondet_monad_cont/wrong/early_interleave.log
+++ b/exercises/nondet_monad_cont/wrong/early_interleave.log
@@ -1,0 +1,2 @@
+Learnocaml v.0.10 running.
+[ Loading the prelude. ][K[ Preparing the test environment. ][K[ Loading your code. ][K[ Loading the solution. ][K[ Preparing to launch the tests. ][K[ Launching the test bench. ][K.                              - Failure - 5 points

--- a/exercises/nondet_monad_cont/wrong/early_interleave.ml
+++ b/exercises/nondet_monad_cont/wrong/early_interleave.ml
@@ -1,0 +1,65 @@
+let return (x : 'a) : 'a m =
+  let compute s f = s x f in
+  { compute }
+
+let (>>=) (m1 : 'a m) (f2 : 'a -> 'b m) : 'b m =
+  let compute s f = m1.compute (fun x f' -> (f2 x).compute s f') f in
+  { compute }
+
+let fail : 'a m =
+  let compute s f = f() in
+  { compute }
+
+let choose (m1 : 'a m) (m2 : 'a m) : 'a m =
+  let compute s f = m1.compute s (fun () -> m2.compute s f) in
+  { compute }
+
+let sols (m : 'a m) : 'a Seq.t =
+  fun () ->
+    m.compute
+      (fun x f -> Seq.Cons (x, f))
+      (fun () -> Seq.Nil)
+
+(* The functions [reflect] and [msplit] witness an isomorphism between the
+   type ['a m] and the type [unit -> ('a * 'a m) option]. *)
+
+let reflect (o : unit -> ('a * 'a m) option) : 'a m =
+  delay (fun () ->
+    match o() with
+    | None ->
+        fail
+    | Some (x, m) ->
+        choose (return x) m
+  )
+
+let msplit (m : 'a m) : unit -> ('a * 'a m) option =
+  fun () ->
+    m.compute
+      (fun x f -> Some (x, reflect f))
+      (fun () -> None)
+
+let at_most_once (m : 'a m) : 'a m =
+  delay (fun () ->
+    match msplit m () with
+    | None ->
+        fail
+    | Some (x, _) ->
+        return x
+  )
+
+let rec interleave (m1 : 'a m) (m2 : 'a m) : 'a m =
+  (* wrong: missing [delay] *)
+  match msplit m1 () with
+  | None ->
+      m2
+  | Some (x1, m1) ->
+      choose (return x1) (interleave m2 m1)
+
+let rec (>>-) (m1 : 'a m) (f2 : 'a -> 'b m) : 'b m =
+  delay (fun () ->
+    match msplit m1 () with
+    | None ->
+        fail
+    | Some (x1, m1) ->
+        interleave (f2 x1) (m1 >>- f2)
+  )

--- a/exercises/nondet_monad_cont/wrong/early_interleave.report.txt
+++ b/exercises/nondet_monad_cont/wrong/early_interleave.report.txt
@@ -1,0 +1,42 @@
+Question 1
+  Found [return] with compatible type.
+  Found [>>=] with compatible type.
+  Found [fail] with compatible type.
+  Found [choose] with compatible type.
+  Found [sols] with compatible type.
+  Functional correctness
+    Success 1: The code seems correct. Tested 2411 scenarios.
+  Laziness
+    Success 1: The code seems lazy.
+Question 2
+  Found [return] with compatible type.
+  Found [>>=] with compatible type.
+  Found [fail] with compatible type.
+  Found [choose] with compatible type.
+  Found [sols] with compatible type.
+  Found [at_most_once] with compatible type.
+  Functional correctness
+    Success 1: The code seems correct. Tested 2486 scenarios.
+  Laziness
+    Success 1: The code seems lazy.
+Question 3
+  Found [return] with compatible type.
+  Found [>>=] with compatible type.
+  Found [fail] with compatible type.
+  Found [choose] with compatible type.
+  Found [sols] with compatible type.
+  Found [at_most_once] with compatible type.
+  Found [interleave] with compatible type.
+  Functional correctness
+    Success 1: The code seems correct. Tested 2867 scenarios.
+  Laziness
+    Failure: Some computations take place too early. The following
+             expression:
+      
+       | Seq.map snapshot sols (interleave (tick (return 0)) (tick (return 0)))
+       | |> Seq.take 20
+       | |> Seq.to_list
+      produces the following result: [[((* value: *) 0, (* work: *) 2); ((*
+      value: *) 0, (* work: *) 2)]] This is invalid. Producing the following
+      result is valid: [[((* value: *) 0, (* work: *) 1); ((* value: *) 0, (*
+      work: *) 2)]]

--- a/exercises/nondet_monad_cont/wrong/early_sols.log
+++ b/exercises/nondet_monad_cont/wrong/early_sols.log
@@ -1,0 +1,2 @@
+Learnocaml v.0.10 running.
+[ Loading the prelude. ][K[ Preparing the test environment. ][K[ Loading your code. ][K[ Loading the solution. ][K[ Preparing to launch the tests. ][K[ Launching the test bench. ][K.                              - Failure - 1 points

--- a/exercises/nondet_monad_cont/wrong/early_sols.ml
+++ b/exercises/nondet_monad_cont/wrong/early_sols.ml
@@ -1,0 +1,36 @@
+let return (x : 'a) : 'a m =
+  let compute s f = s x f in
+  { compute }
+
+let (>>=) (m1 : 'a m) (f2 : 'a -> 'b m) : 'b m =
+  let compute s f = m1.compute (fun x f' -> (f2 x).compute s f') f in
+  { compute }
+
+let fail : 'a m =
+  let compute s f = f() in
+  { compute }
+
+let choose (m1 : 'a m) (m2 : 'a m) : 'a m =
+  let compute s f = m1.compute s (fun () -> m2.compute s f) in
+  { compute }
+
+let sols (m : 'a m) : 'a Seq.t =
+  fun () ->
+    m.compute
+      (fun x f -> Seq.Cons (x, f))
+      (fun () -> Seq.Nil)
+
+let rec eager_of_seq (xs : 'a Seq.t) : 'a m =
+  match xs() with
+  | Seq.Nil ->
+      fail
+  | Seq.Cons (x, xs) ->
+      choose (return x) (eager_of_seq xs)
+
+let force (m : 'a m) : 'a m =
+  eager_of_seq (sols m)
+
+(* Sabotage [sols]. *)
+
+let sols m =
+  sols (force m)

--- a/exercises/nondet_monad_cont/wrong/early_sols.report.txt
+++ b/exercises/nondet_monad_cont/wrong/early_sols.report.txt
@@ -1,0 +1,19 @@
+Question 1
+  Found [return] with compatible type.
+  Found [>>=] with compatible type.
+  Found [fail] with compatible type.
+  Found [choose] with compatible type.
+  Found [sols] with compatible type.
+  Functional correctness
+    Success 1: The code seems correct. Tested 2411 scenarios.
+  Laziness
+    Failure: Some computations take place too early. The following
+             expression:
+      
+       | Seq.map snapshot sols (choose (tick (return 0)) (tick (return 0)))
+       | |> Seq.take 20
+       | |> Seq.to_list
+      produces the following result: [[((* value: *) 0, (* work: *) 2); ((*
+      value: *) 0, (* work: *) 2)]] This is invalid. Producing the following
+      result is valid: [[((* value: *) 0, (* work: *) 1); ((* value: *) 0, (*
+      work: *) 2)]]

--- a/exercises/nondet_monad_cont/wrong/fail_twice.log
+++ b/exercises/nondet_monad_cont/wrong/fail_twice.log
@@ -1,0 +1,2 @@
+Learnocaml v.0.10 running.
+[ Loading the prelude. ][K[ Preparing the test environment. ][K[ Loading your code. ][K[ Loading the solution. ][K[ Preparing to launch the tests. ][K[ Launching the test bench. ][K.                              - Failure - 1 points

--- a/exercises/nondet_monad_cont/wrong/fail_twice.ml
+++ b/exercises/nondet_monad_cont/wrong/fail_twice.ml
@@ -1,0 +1,66 @@
+let return (x : 'a) : 'a m =
+  let compute s f = s x f in
+  { compute }
+
+let (>>=) (m1 : 'a m) (f2 : 'a -> 'b m) : 'b m =
+  let compute s f = m1.compute (fun x f' -> (f2 x).compute s f') f in
+  { compute }
+
+let fail : 'a m =
+  let compute s f = f(); f() in (* wrong *)
+  { compute }
+
+let choose (m1 : 'a m) (m2 : 'a m) : 'a m =
+  let compute s f = m1.compute s (fun () -> m2.compute s f) in
+  { compute }
+
+let sols (m : 'a m) : 'a Seq.t =
+  fun () ->
+    m.compute
+      (fun x f -> Seq.Cons (x, f))
+      (fun () -> Seq.Nil)
+
+(* The functions [reflect] and [msplit] witness an isomorphism between the
+   type ['a m] and the type [unit -> ('a * 'a m) option]. *)
+
+let reflect (o : unit -> ('a * 'a m) option) : 'a m =
+  delay (fun () ->
+    match o() with
+    | None ->
+        fail
+    | Some (x, m) ->
+        choose (return x) m
+  )
+
+let msplit (m : 'a m) : unit -> ('a * 'a m) option =
+  fun () ->
+    m.compute
+      (fun x f -> Some (x, reflect f))
+      (fun () -> None)
+
+let at_most_once (m : 'a m) : 'a m =
+  delay (fun () ->
+    match msplit m () with
+    | None ->
+        fail
+    | Some (x, _) ->
+        return x
+  )
+
+let rec interleave (m1 : 'a m) (m2 : 'a m) : 'a m =
+  delay (fun () ->
+    match msplit m1 () with
+    | None ->
+        m2
+    | Some (x1, m1) ->
+        choose (return x1) (interleave m2 m1)
+  )
+
+let rec (>>-) (m1 : 'a m) (f2 : 'a -> 'b m) : 'b m =
+  delay (fun () ->
+    match msplit m1 () with
+    | None ->
+        fail
+    | Some (x1, m1) ->
+        interleave (f2 x1) (m1 >>- f2)
+  )

--- a/exercises/nondet_monad_cont/wrong/fail_twice.report.txt
+++ b/exercises/nondet_monad_cont/wrong/fail_twice.report.txt
@@ -1,0 +1,18 @@
+Question 1
+  Found [return] with compatible type.
+  Found [>>=] with compatible type.
+  Found [fail] with compatible type.
+  Found [choose] with compatible type.
+  Found [sols] with compatible type.
+  Functional correctness
+    Success 1: The code seems correct. Tested 2411 scenarios.
+  Laziness
+    Failure: Some computations take place too early. The following
+             expression:
+      
+       | Seq.map snapshot sols (choose (tick fail) (tick (return 0)))
+       | |> Seq.take 20
+       | |> Seq.to_list
+      produces the following result: [[((* value: *) 0, (* work: *) 3)]] This
+      is invalid. Producing the following result is valid: [[((* value: *) 0,
+      (* work: *) 2)]]

--- a/exercises/nondet_monad_cont/wrong/fair_bind_choose.log
+++ b/exercises/nondet_monad_cont/wrong/fair_bind_choose.log
@@ -1,0 +1,2 @@
+Learnocaml v.0.10 running.
+[ Loading the prelude. ][K[ Preparing the test environment. ][K[ Loading your code. ][K[ Loading the solution. ][K[ Preparing to launch the tests. ][K[ Launching the test bench. ][K.                              - Failure - 6 points

--- a/exercises/nondet_monad_cont/wrong/fair_bind_choose.ml
+++ b/exercises/nondet_monad_cont/wrong/fair_bind_choose.ml
@@ -1,0 +1,67 @@
+let return (x : 'a) : 'a m =
+  let compute s f = s x f in
+  { compute }
+
+let (>>=) (m1 : 'a m) (f2 : 'a -> 'b m) : 'b m =
+  let compute s f = m1.compute (fun x f' -> (f2 x).compute s f') f in
+  { compute }
+
+let fail : 'a m =
+  let compute s f = f() in
+  { compute }
+
+let choose (m1 : 'a m) (m2 : 'a m) : 'a m =
+  let compute s f = m1.compute s (fun () -> m2.compute s f) in
+  { compute }
+
+let sols (m : 'a m) : 'a Seq.t =
+  fun () ->
+    m.compute
+      (fun x f -> Seq.Cons (x, f))
+      (fun () -> Seq.Nil)
+
+(* The functions [reflect] and [msplit] witness an isomorphism between the
+   type ['a m] and the type [unit -> ('a * 'a m) option]. *)
+
+let reflect (o : unit -> ('a * 'a m) option) : 'a m =
+  delay (fun () ->
+    match o() with
+    | None ->
+        fail
+    | Some (x, m) ->
+        choose (return x) m
+  )
+
+let msplit (m : 'a m) : unit -> ('a * 'a m) option =
+  fun () ->
+    m.compute
+      (fun x f -> Some (x, reflect f))
+      (fun () -> None)
+
+let at_most_once (m : 'a m) : 'a m =
+  delay (fun () ->
+    match msplit m () with
+    | None ->
+        fail
+    | Some (x, _) ->
+        return x
+  )
+
+let rec interleave (m1 : 'a m) (m2 : 'a m) : 'a m =
+  delay (fun () ->
+    match msplit m1 () with
+    | None ->
+        m2
+    | Some (x1, m1) ->
+        choose (return x1) (interleave m2 m1)
+  )
+
+let rec (>>-) (m1 : 'a m) (f2 : 'a -> 'b m) : 'b m =
+  delay (fun () ->
+    match msplit m1 () with
+    | None ->
+        fail
+    | Some (x1, m1) ->
+        (* wrong: use [choose] instead of [interleave] *)
+        choose (f2 x1) (m1 >>- f2)
+  )

--- a/exercises/nondet_monad_cont/wrong/fair_bind_choose.report.txt
+++ b/exercises/nondet_monad_cont/wrong/fair_bind_choose.report.txt
@@ -1,0 +1,53 @@
+Question 1
+  Found [return] with compatible type.
+  Found [>>=] with compatible type.
+  Found [fail] with compatible type.
+  Found [choose] with compatible type.
+  Found [sols] with compatible type.
+  Functional correctness
+    Success 1: The code seems correct. Tested 2411 scenarios.
+  Laziness
+    Success 1: The code seems lazy.
+Question 2
+  Found [return] with compatible type.
+  Found [>>=] with compatible type.
+  Found [fail] with compatible type.
+  Found [choose] with compatible type.
+  Found [sols] with compatible type.
+  Found [at_most_once] with compatible type.
+  Functional correctness
+    Success 1: The code seems correct. Tested 2486 scenarios.
+  Laziness
+    Success 1: The code seems lazy.
+Question 3
+  Found [return] with compatible type.
+  Found [>>=] with compatible type.
+  Found [fail] with compatible type.
+  Found [choose] with compatible type.
+  Found [sols] with compatible type.
+  Found [at_most_once] with compatible type.
+  Found [interleave] with compatible type.
+  Functional correctness
+    Success 1: The code seems correct. Tested 2867 scenarios.
+  Laziness
+    Success 1: The code seems lazy.
+Question 4
+  Found [return] with compatible type.
+  Found [>>=] with compatible type.
+  Found [fail] with compatible type.
+  Found [choose] with compatible type.
+  Found [sols] with compatible type.
+  Found [at_most_once] with compatible type.
+  Found [interleave] with compatible type.
+  Found [>>-] with compatible type.
+  Functional correctness
+    Failure: Something is wrong. The following expression:
+      
+       | sols (
+       |   interleave (return 0) (return 1) >>- fun a ->
+       |   choose (return 0) (return 1)
+       | )
+       | |> Seq.take 20
+       | |> Seq.to_list
+      produces the following result: [[0; 1; 0; 1]] This is invalid.
+      Producing the following result is valid: [[0; 0; 1; 1]]

--- a/exercises/nondet_monad_cont/wrong/fair_bind_self.log
+++ b/exercises/nondet_monad_cont/wrong/fair_bind_self.log
@@ -1,0 +1,2 @@
+Learnocaml v.0.10 running.
+[ Loading the prelude. ][K[ Preparing the test environment. ][K[ Loading your code. ][K[ Loading the solution. ][K[ Preparing to launch the tests. ][K[ Launching the test bench. ][K.                              - Failure - 6 points

--- a/exercises/nondet_monad_cont/wrong/fair_bind_self.ml
+++ b/exercises/nondet_monad_cont/wrong/fair_bind_self.ml
@@ -1,0 +1,67 @@
+let return (x : 'a) : 'a m =
+  let compute s f = s x f in
+  { compute }
+
+let (>>=) (m1 : 'a m) (f2 : 'a -> 'b m) : 'b m =
+  let compute s f = m1.compute (fun x f' -> (f2 x).compute s f') f in
+  { compute }
+
+let fail : 'a m =
+  let compute s f = f() in
+  { compute }
+
+let choose (m1 : 'a m) (m2 : 'a m) : 'a m =
+  let compute s f = m1.compute s (fun () -> m2.compute s f) in
+  { compute }
+
+let sols (m : 'a m) : 'a Seq.t =
+  fun () ->
+    m.compute
+      (fun x f -> Seq.Cons (x, f))
+      (fun () -> Seq.Nil)
+
+(* The functions [reflect] and [msplit] witness an isomorphism between the
+   type ['a m] and the type [unit -> ('a * 'a m) option]. *)
+
+let reflect (o : unit -> ('a * 'a m) option) : 'a m =
+  delay (fun () ->
+    match o() with
+    | None ->
+        fail
+    | Some (x, m) ->
+        choose (return x) m
+  )
+
+let msplit (m : 'a m) : unit -> ('a * 'a m) option =
+  fun () ->
+    m.compute
+      (fun x f -> Some (x, reflect f))
+      (fun () -> None)
+
+let at_most_once (m : 'a m) : 'a m =
+  delay (fun () ->
+    match msplit m () with
+    | None ->
+        fail
+    | Some (x, _) ->
+        return x
+  )
+
+let rec interleave (m1 : 'a m) (m2 : 'a m) : 'a m =
+  delay (fun () ->
+    match msplit m1 () with
+    | None ->
+        m2
+    | Some (x1, m1) ->
+        choose (return x1) (interleave m2 m1)
+  )
+
+let rec (>>-) (m1 : 'a m) (f2 : 'a -> 'b m) : 'b m =
+  delay (fun () ->
+    match msplit m1 () with
+    | None ->
+        fail
+    | Some (x1, m1) ->
+        (* wrong: use [>>=] instead of [>>-] *)
+        interleave (f2 x1) (m1 >>= f2)
+  )

--- a/exercises/nondet_monad_cont/wrong/fair_bind_self.report.txt
+++ b/exercises/nondet_monad_cont/wrong/fair_bind_self.report.txt
@@ -1,0 +1,53 @@
+Question 1
+  Found [return] with compatible type.
+  Found [>>=] with compatible type.
+  Found [fail] with compatible type.
+  Found [choose] with compatible type.
+  Found [sols] with compatible type.
+  Functional correctness
+    Success 1: The code seems correct. Tested 2411 scenarios.
+  Laziness
+    Success 1: The code seems lazy.
+Question 2
+  Found [return] with compatible type.
+  Found [>>=] with compatible type.
+  Found [fail] with compatible type.
+  Found [choose] with compatible type.
+  Found [sols] with compatible type.
+  Found [at_most_once] with compatible type.
+  Functional correctness
+    Success 1: The code seems correct. Tested 2486 scenarios.
+  Laziness
+    Success 1: The code seems lazy.
+Question 3
+  Found [return] with compatible type.
+  Found [>>=] with compatible type.
+  Found [fail] with compatible type.
+  Found [choose] with compatible type.
+  Found [sols] with compatible type.
+  Found [at_most_once] with compatible type.
+  Found [interleave] with compatible type.
+  Functional correctness
+    Success 1: The code seems correct. Tested 2867 scenarios.
+  Laziness
+    Success 1: The code seems lazy.
+Question 4
+  Found [return] with compatible type.
+  Found [>>=] with compatible type.
+  Found [fail] with compatible type.
+  Found [choose] with compatible type.
+  Found [sols] with compatible type.
+  Found [at_most_once] with compatible type.
+  Found [interleave] with compatible type.
+  Found [>>-] with compatible type.
+  Functional correctness
+    Failure: Something is wrong. The following expression:
+      
+       | sols (
+       |   choose (interleave (return 0) (return 0)) (return 0) >>- fun a ->
+       |   choose (return 1 >>= fun b -> return b) (return 0)
+       | )
+       | |> Seq.take 20
+       | |> Seq.to_list
+      produces the following result: [[1; 1; 0; 0; 1; 0]] This is invalid.
+      Producing the following result is valid: [[1; 1; 0; 1; 0; 0]]

--- a/exercises/nondet_monad_cont/wrong/interleave_choose.log
+++ b/exercises/nondet_monad_cont/wrong/interleave_choose.log
@@ -1,0 +1,2 @@
+Learnocaml v.0.10 running.
+[ Loading the prelude. ][K[ Preparing the test environment. ][K[ Loading your code. ][K[ Loading the solution. ][K[ Preparing to launch the tests. ][K[ Launching the test bench. ][K.                              - Failure - 4 points

--- a/exercises/nondet_monad_cont/wrong/interleave_choose.ml
+++ b/exercises/nondet_monad_cont/wrong/interleave_choose.ml
@@ -1,0 +1,51 @@
+let return (x : 'a) : 'a m =
+  let compute s f = s x f in
+  { compute }
+
+let (>>=) (m1 : 'a m) (f2 : 'a -> 'b m) : 'b m =
+  let compute s f = m1.compute (fun x f' -> (f2 x).compute s f') f in
+  { compute }
+
+let fail : 'a m =
+  let compute s f = f() in
+  { compute }
+
+let choose (m1 : 'a m) (m2 : 'a m) : 'a m =
+  let compute s f = m1.compute s (fun () -> m2.compute s f) in
+  { compute }
+
+let sols (m : 'a m) : 'a Seq.t =
+  fun () ->
+    m.compute
+      (fun x f -> Seq.Cons (x, f))
+      (fun () -> Seq.Nil)
+
+(* The functions [reflect] and [msplit] witness an isomorphism between the
+   type ['a m] and the type [unit -> ('a * 'a m) option]. *)
+
+let reflect (o : unit -> ('a * 'a m) option) : 'a m =
+  delay (fun () ->
+    match o() with
+    | None ->
+        fail
+    | Some (x, m) ->
+        choose (return x) m
+  )
+
+let msplit (m : 'a m) : unit -> ('a * 'a m) option =
+  fun () ->
+    m.compute
+      (fun x f -> Some (x, reflect f))
+      (fun () -> None)
+
+let at_most_once (m : 'a m) : 'a m =
+  delay (fun () ->
+    match msplit m () with
+    | None ->
+        fail
+    | Some (x, _) ->
+        return x
+  )
+
+let interleave =
+  choose (* basic attempt at cheating *)

--- a/exercises/nondet_monad_cont/wrong/interleave_choose.report.txt
+++ b/exercises/nondet_monad_cont/wrong/interleave_choose.report.txt
@@ -1,0 +1,37 @@
+Question 1
+  Found [return] with compatible type.
+  Found [>>=] with compatible type.
+  Found [fail] with compatible type.
+  Found [choose] with compatible type.
+  Found [sols] with compatible type.
+  Functional correctness
+    Success 1: The code seems correct. Tested 2411 scenarios.
+  Laziness
+    Success 1: The code seems lazy.
+Question 2
+  Found [return] with compatible type.
+  Found [>>=] with compatible type.
+  Found [fail] with compatible type.
+  Found [choose] with compatible type.
+  Found [sols] with compatible type.
+  Found [at_most_once] with compatible type.
+  Functional correctness
+    Success 1: The code seems correct. Tested 2486 scenarios.
+  Laziness
+    Success 1: The code seems lazy.
+Question 3
+  Found [return] with compatible type.
+  Found [>>=] with compatible type.
+  Found [fail] with compatible type.
+  Found [choose] with compatible type.
+  Found [sols] with compatible type.
+  Found [at_most_once] with compatible type.
+  Found [interleave] with compatible type.
+  Functional correctness
+    Failure: Something is wrong. The following expression:
+      
+       | sols (interleave (choose (return 0) (return 0)) (return 1))
+       | |> Seq.take 20
+       | |> Seq.to_list
+      produces the following result: [[0; 0; 1]] This is invalid. Producing
+      the following result is valid: [[0; 1; 0]]

--- a/exercises/nondet_monad_cont/wrong/interleave_flaw.log
+++ b/exercises/nondet_monad_cont/wrong/interleave_flaw.log
@@ -1,0 +1,2 @@
+Learnocaml v.0.10 running.
+[ Loading the prelude. ][K[ Preparing the test environment. ][K[ Loading your code. ][K[ Loading the solution. ][K[ Preparing to launch the tests. ][K[ Launching the test bench. ][K.                              - Failure - 4 points

--- a/exercises/nondet_monad_cont/wrong/interleave_flaw.ml
+++ b/exercises/nondet_monad_cont/wrong/interleave_flaw.ml
@@ -1,0 +1,66 @@
+let return (x : 'a) : 'a m =
+  let compute s f = s x f in
+  { compute }
+
+let (>>=) (m1 : 'a m) (f2 : 'a -> 'b m) : 'b m =
+  let compute s f = m1.compute (fun x f' -> (f2 x).compute s f') f in
+  { compute }
+
+let fail : 'a m =
+  let compute s f = f() in
+  { compute }
+
+let choose (m1 : 'a m) (m2 : 'a m) : 'a m =
+  let compute s f = m1.compute s (fun () -> m2.compute s f) in
+  { compute }
+
+let sols (m : 'a m) : 'a Seq.t =
+  fun () ->
+    m.compute
+      (fun x f -> Seq.Cons (x, f))
+      (fun () -> Seq.Nil)
+
+(* The functions [reflect] and [msplit] witness an isomorphism between the
+   type ['a m] and the type [unit -> ('a * 'a m) option]. *)
+
+let reflect (o : unit -> ('a * 'a m) option) : 'a m =
+  delay (fun () ->
+    match o() with
+    | None ->
+        fail
+    | Some (x, m) ->
+        choose (return x) m
+  )
+
+let msplit (m : 'a m) : unit -> ('a * 'a m) option =
+  fun () ->
+    m.compute
+      (fun x f -> Some (x, reflect f))
+      (fun () -> None)
+
+let at_most_once (m : 'a m) : 'a m =
+  delay (fun () ->
+    match msplit m () with
+    | None ->
+        fail
+    | Some (x, _) ->
+        return x
+  )
+
+let rec interleave (m1 : 'a m) (m2 : 'a m) : 'a m =
+  delay (fun () ->
+    match msplit m1 () with
+    | None ->
+        fail (* wrong: should be [m2] *)
+    | Some (x1, m1) ->
+        choose (return x1) (interleave m2 m1)
+  )
+
+let rec (>>-) (m1 : 'a m) (f2 : 'a -> 'b m) : 'b m =
+  delay (fun () ->
+    match msplit m1 () with
+    | None ->
+        fail
+    | Some (x1, m1) ->
+        interleave (f2 x1) (m1 >>- f2)
+  )

--- a/exercises/nondet_monad_cont/wrong/interleave_flaw.report.txt
+++ b/exercises/nondet_monad_cont/wrong/interleave_flaw.report.txt
@@ -1,0 +1,35 @@
+Question 1
+  Found [return] with compatible type.
+  Found [>>=] with compatible type.
+  Found [fail] with compatible type.
+  Found [choose] with compatible type.
+  Found [sols] with compatible type.
+  Functional correctness
+    Success 1: The code seems correct. Tested 2411 scenarios.
+  Laziness
+    Success 1: The code seems lazy.
+Question 2
+  Found [return] with compatible type.
+  Found [>>=] with compatible type.
+  Found [fail] with compatible type.
+  Found [choose] with compatible type.
+  Found [sols] with compatible type.
+  Found [at_most_once] with compatible type.
+  Functional correctness
+    Success 1: The code seems correct. Tested 2486 scenarios.
+  Laziness
+    Success 1: The code seems lazy.
+Question 3
+  Found [return] with compatible type.
+  Found [>>=] with compatible type.
+  Found [fail] with compatible type.
+  Found [choose] with compatible type.
+  Found [sols] with compatible type.
+  Found [at_most_once] with compatible type.
+  Found [interleave] with compatible type.
+  Functional correctness
+    Failure: Something is wrong. The following expression:
+      
+       | sols (interleave fail (return 0)) |> Seq.take 20 |> Seq.to_list
+      produces the following result: [[]] This is invalid. Producing the
+      following result is valid: [[0]]

--- a/exercises/nondet_monad_cont/wrong/naive_sols.log
+++ b/exercises/nondet_monad_cont/wrong/naive_sols.log
@@ -1,0 +1,2 @@
+Learnocaml v.0.10 running.
+[ Loading the prelude. ][K[ Preparing the test environment. ][K[ Loading your code. ][K[ Loading the solution. ][K[ Preparing to launch the tests. ][K[ Launching the test bench. ][K.                              - Failure - 1 points

--- a/exercises/nondet_monad_cont/wrong/naive_sols.ml
+++ b/exercises/nondet_monad_cont/wrong/naive_sols.ml
@@ -1,0 +1,66 @@
+let return (x : 'a) : 'a m =
+  let compute s f = s x f in
+  { compute }
+
+let (>>=) (m1 : 'a m) (f2 : 'a -> 'b m) : 'b m =
+  let compute s f = m1.compute (fun x f' -> (f2 x).compute s f') f in
+  { compute }
+
+let fail : 'a m =
+  let compute s f = f() in
+  { compute }
+
+let choose (m1 : 'a m) (m2 : 'a m) : 'a m =
+  let compute s f = m1.compute s (fun () -> m2.compute s f) in
+  { compute }
+
+let sols (m : 'a m) : 'a Seq.t =
+  (* wrong: not appropriately delayed *)
+  m.compute
+    (fun x f -> Seq.cons x (f()))
+    (fun () -> Seq.nil)
+
+(* The functions [reflect] and [msplit] witness an isomorphism between the
+   type ['a m] and the type [unit -> ('a * 'a m) option]. *)
+
+let reflect (o : unit -> ('a * 'a m) option) : 'a m =
+  delay (fun () ->
+    match o() with
+    | None ->
+        fail
+    | Some (x, m) ->
+        choose (return x) m
+  )
+
+let msplit (m : 'a m) : unit -> ('a * 'a m) option =
+  fun () ->
+    m.compute
+      (fun x f -> Some (x, reflect f))
+      (fun () -> None)
+
+let at_most_once (m : 'a m) : 'a m =
+  delay (fun () ->
+    match msplit m () with
+    | None ->
+        fail
+    | Some (x, _) ->
+        return x
+  )
+
+let rec interleave (m1 : 'a m) (m2 : 'a m) : 'a m =
+  delay (fun () ->
+    match msplit m1 () with
+    | None ->
+        m2
+    | Some (x1, m1) ->
+        choose (return x1) (interleave m2 m1)
+  )
+
+let rec (>>-) (m1 : 'a m) (f2 : 'a -> 'b m) : 'b m =
+  delay (fun () ->
+    match msplit m1 () with
+    | None ->
+        fail
+    | Some (x1, m1) ->
+        interleave (f2 x1) (m1 >>- f2)
+  )

--- a/exercises/nondet_monad_cont/wrong/naive_sols.report.txt
+++ b/exercises/nondet_monad_cont/wrong/naive_sols.report.txt
@@ -1,0 +1,19 @@
+Question 1
+  Found [return] with compatible type.
+  Found [>>=] with compatible type.
+  Found [fail] with compatible type.
+  Found [choose] with compatible type.
+  Found [sols] with compatible type.
+  Functional correctness
+    Success 1: The code seems correct. Tested 2411 scenarios.
+  Laziness
+    Failure: Some computations take place too early. The following
+             expression:
+      
+       | Seq.map snapshot sols (choose (tick (return 0)) (tick (return 0)))
+       | |> Seq.take 20
+       | |> Seq.to_list
+      produces the following result: [[((* value: *) 0, (* work: *) 2); ((*
+      value: *) 0, (* work: *) 2)]] This is invalid. Producing the following
+      result is valid: [[((* value: *) 0, (* work: *) 1); ((* value: *) 0, (*
+      work: *) 2)]]

--- a/exercises/nondet_monad_cont/wrong/return_double.log
+++ b/exercises/nondet_monad_cont/wrong/return_double.log
@@ -1,0 +1,2 @@
+Learnocaml v.0.10 running.
+[ Loading the prelude. ][K[ Preparing the test environment. ][K[ Loading your code. ][K[ Loading the solution. ][K[ Preparing to launch the tests. ][K[ Launching the test bench. ][K.                              - Failure - 0 points

--- a/exercises/nondet_monad_cont/wrong/return_double.ml
+++ b/exercises/nondet_monad_cont/wrong/return_double.ml
@@ -1,0 +1,67 @@
+let return (x : 'a) : 'a m =
+  (* wrong: return [x] twice *)
+  let compute s f = s x (fun () -> s x f) in
+  { compute }
+
+let (>>=) (m1 : 'a m) (f2 : 'a -> 'b m) : 'b m =
+  let compute s f = m1.compute (fun x f' -> (f2 x).compute s f') f in
+  { compute }
+
+let fail : 'a m =
+  let compute s f = f() in
+  { compute }
+
+let choose (m1 : 'a m) (m2 : 'a m) : 'a m =
+  let compute s f = m1.compute s (fun () -> m2.compute s f) in
+  { compute }
+
+let sols (m : 'a m) : 'a Seq.t =
+  fun () ->
+    m.compute
+      (fun x f -> Seq.Cons (x, f))
+      (fun () -> Seq.Nil)
+
+(* The functions [reflect] and [msplit] witness an isomorphism between the
+   type ['a m] and the type [unit -> ('a * 'a m) option]. *)
+
+let reflect (o : unit -> ('a * 'a m) option) : 'a m =
+  delay (fun () ->
+    match o() with
+    | None ->
+        fail
+    | Some (x, m) ->
+        choose (return x) m
+  )
+
+let msplit (m : 'a m) : unit -> ('a * 'a m) option =
+  fun () ->
+    m.compute
+      (fun x f -> Some (x, reflect f))
+      (fun () -> None)
+
+let at_most_once (m : 'a m) : 'a m =
+  delay (fun () ->
+    match msplit m () with
+    | None ->
+        fail
+    | Some (x, _) ->
+        return x
+  )
+
+let rec interleave (m1 : 'a m) (m2 : 'a m) : 'a m =
+  delay (fun () ->
+    match msplit m1 () with
+    | None ->
+        m2
+    | Some (x1, m1) ->
+        choose (return x1) (interleave m2 m1)
+  )
+
+let rec (>>-) (m1 : 'a m) (f2 : 'a -> 'b m) : 'b m =
+  delay (fun () ->
+    match msplit m1 () with
+    | None ->
+        fail
+    | Some (x1, m1) ->
+        interleave (f2 x1) (m1 >>- f2)
+  )

--- a/exercises/nondet_monad_cont/wrong/return_double.report.txt
+++ b/exercises/nondet_monad_cont/wrong/return_double.report.txt
@@ -1,0 +1,12 @@
+Question 1
+  Found [return] with compatible type.
+  Found [>>=] with compatible type.
+  Found [fail] with compatible type.
+  Found [choose] with compatible type.
+  Found [sols] with compatible type.
+  Functional correctness
+    Failure: Something is wrong. The following expression:
+      
+       | sols (return 0) |> Seq.take 20 |> Seq.to_list
+      produces the following result: [[0; 0]] This is invalid. Producing the
+      following result is valid: [[0]]

--- a/exercises/nondet_monad_cont/wrong/return_dup.log
+++ b/exercises/nondet_monad_cont/wrong/return_dup.log
@@ -1,0 +1,2 @@
+Learnocaml v.0.10 running.
+[ Loading the prelude. ][K[ Preparing the test environment. ][K[ Loading your code. ][K[ Loading the solution. ][K[ Preparing to launch the tests. ][K[ Launching the test bench. ][K.                              - Failure - 1 points

--- a/exercises/nondet_monad_cont/wrong/return_dup.ml
+++ b/exercises/nondet_monad_cont/wrong/return_dup.ml
@@ -1,0 +1,71 @@
+let return (x : 'a) : 'a m =
+  let compute s f =
+    (* wrong and very bizarre: call continuation twice,
+       discard one result *)
+    let _ = s x f in
+    s x f
+  in
+  { compute }
+
+let (>>=) (m1 : 'a m) (f2 : 'a -> 'b m) : 'b m =
+  let compute s f = m1.compute (fun x f' -> (f2 x).compute s f') f in
+  { compute }
+
+let fail : 'a m =
+  let compute s f = f() in
+  { compute }
+
+let choose (m1 : 'a m) (m2 : 'a m) : 'a m =
+  let compute s f = m1.compute s (fun () -> m2.compute s f) in
+  { compute }
+
+let sols (m : 'a m) : 'a Seq.t =
+  fun () ->
+    m.compute
+      (fun x f -> Seq.Cons (x, f))
+      (fun () -> Seq.Nil)
+
+(* The functions [reflect] and [msplit] witness an isomorphism between the
+   type ['a m] and the type [unit -> ('a * 'a m) option]. *)
+
+let reflect (o : unit -> ('a * 'a m) option) : 'a m =
+  delay (fun () ->
+    match o() with
+    | None ->
+        fail
+    | Some (x, m) ->
+        choose (return x) m
+  )
+
+let msplit (m : 'a m) : unit -> ('a * 'a m) option =
+  fun () ->
+    m.compute
+      (fun x f -> Some (x, reflect f))
+      (fun () -> None)
+
+let at_most_once (m : 'a m) : 'a m =
+  delay (fun () ->
+    match msplit m () with
+    | None ->
+        fail
+    | Some (x, _) ->
+        return x
+  )
+
+let rec interleave (m1 : 'a m) (m2 : 'a m) : 'a m =
+  delay (fun () ->
+    match msplit m1 () with
+    | None ->
+        m2
+    | Some (x1, m1) ->
+        choose (return x1) (interleave m2 m1)
+  )
+
+let rec (>>-) (m1 : 'a m) (f2 : 'a -> 'b m) : 'b m =
+  delay (fun () ->
+    match msplit m1 () with
+    | None ->
+        fail
+    | Some (x1, m1) ->
+        interleave (f2 x1) (m1 >>- f2)
+  )

--- a/exercises/nondet_monad_cont/wrong/return_dup.report.txt
+++ b/exercises/nondet_monad_cont/wrong/return_dup.report.txt
@@ -1,0 +1,18 @@
+Question 1
+  Found [return] with compatible type.
+  Found [>>=] with compatible type.
+  Found [fail] with compatible type.
+  Found [choose] with compatible type.
+  Found [sols] with compatible type.
+  Functional correctness
+    Success 1: The code seems correct. Tested 2411 scenarios.
+  Laziness
+    Failure: Some computations take place too early. The following
+             expression:
+      
+       | Seq.map snapshot sols (tick (return 0) >>= fun a -> tick (return a))
+       | |> Seq.take 20
+       | |> Seq.to_list
+      produces the following result: [[((* value: *) 0, (* work: *) 3)]] This
+      is invalid. Producing the following result is valid: [[((* value: *) 0,
+      (* work: *) 2)]]

--- a/exercises/nondet_monad_cont/wrong/return_infinite.log
+++ b/exercises/nondet_monad_cont/wrong/return_infinite.log
@@ -1,0 +1,2 @@
+Learnocaml v.0.10 running.
+[ Loading the prelude. ][K[ Preparing the test environment. ][K[ Loading your code. ][K[ Loading the solution. ][K[ Preparing to launch the tests. ][K[ Launching the test bench. ][K.                              - Failure - 0 points

--- a/exercises/nondet_monad_cont/wrong/return_infinite.ml
+++ b/exercises/nondet_monad_cont/wrong/return_infinite.ml
@@ -1,0 +1,67 @@
+let return (x : 'a) : 'a m =
+  (* wrong: return [x] indefinitely *)
+  let rec compute s f = s x (fun () -> compute s f) in
+  { compute }
+
+let (>>=) (m1 : 'a m) (f2 : 'a -> 'b m) : 'b m =
+  let compute s f = m1.compute (fun x f' -> (f2 x).compute s f') f in
+  { compute }
+
+let fail : 'a m =
+  let compute s f = f() in
+  { compute }
+
+let choose (m1 : 'a m) (m2 : 'a m) : 'a m =
+  let compute s f = m1.compute s (fun () -> m2.compute s f) in
+  { compute }
+
+let sols (m : 'a m) : 'a Seq.t =
+  fun () ->
+    m.compute
+      (fun x f -> Seq.Cons (x, f))
+      (fun () -> Seq.Nil)
+
+(* The functions [reflect] and [msplit] witness an isomorphism between the
+   type ['a m] and the type [unit -> ('a * 'a m) option]. *)
+
+let reflect (o : unit -> ('a * 'a m) option) : 'a m =
+  delay (fun () ->
+    match o() with
+    | None ->
+        fail
+    | Some (x, m) ->
+        choose (return x) m
+  )
+
+let msplit (m : 'a m) : unit -> ('a * 'a m) option =
+  fun () ->
+    m.compute
+      (fun x f -> Some (x, reflect f))
+      (fun () -> None)
+
+let at_most_once (m : 'a m) : 'a m =
+  delay (fun () ->
+    match msplit m () with
+    | None ->
+        fail
+    | Some (x, _) ->
+        return x
+  )
+
+let rec interleave (m1 : 'a m) (m2 : 'a m) : 'a m =
+  delay (fun () ->
+    match msplit m1 () with
+    | None ->
+        m2
+    | Some (x1, m1) ->
+        choose (return x1) (interleave m2 m1)
+  )
+
+let rec (>>-) (m1 : 'a m) (f2 : 'a -> 'b m) : 'b m =
+  delay (fun () ->
+    match msplit m1 () with
+    | None ->
+        fail
+    | Some (x1, m1) ->
+        interleave (f2 x1) (m1 >>- f2)
+  )

--- a/exercises/nondet_monad_cont/wrong/return_infinite.report.txt
+++ b/exercises/nondet_monad_cont/wrong/return_infinite.report.txt
@@ -1,0 +1,13 @@
+Question 1
+  Found [return] with compatible type.
+  Found [>>=] with compatible type.
+  Found [fail] with compatible type.
+  Found [choose] with compatible type.
+  Found [sols] with compatible type.
+  Functional correctness
+    Failure: Something is wrong. The following expression:
+      
+       | sols (return 0) |> Seq.take 20 |> Seq.to_list
+      produces the following result: [[0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0;
+      0; 0; 0; 0; 0; 0; 0]] This is invalid. Producing the following result
+      is valid: [[0]]

--- a/exercises/nondet_monad_cont/wrong/return_nothing.log
+++ b/exercises/nondet_monad_cont/wrong/return_nothing.log
@@ -1,0 +1,2 @@
+Learnocaml v.0.10 running.
+[ Loading the prelude. ][K[ Preparing the test environment. ][K[ Loading your code. ][K[ Loading the solution. ][K[ Preparing to launch the tests. ][K[ Launching the test bench. ][K.                              - Failure - 0 points

--- a/exercises/nondet_monad_cont/wrong/return_nothing.ml
+++ b/exercises/nondet_monad_cont/wrong/return_nothing.ml
@@ -1,0 +1,65 @@
+let (>>=) (m1 : 'a m) (f2 : 'a -> 'b m) : 'b m =
+  let compute s f = m1.compute (fun x f' -> (f2 x).compute s f') f in
+  { compute }
+
+let fail : 'a m =
+  let compute s f = f() in
+  { compute }
+
+let return x =
+  fail (* wrong *)
+
+let choose (m1 : 'a m) (m2 : 'a m) : 'a m =
+  let compute s f = m1.compute s (fun () -> m2.compute s f) in
+  { compute }
+
+let sols (m : 'a m) : 'a Seq.t =
+  fun () ->
+    m.compute
+      (fun x f -> Seq.Cons (x, f))
+      (fun () -> Seq.Nil)
+
+(* The functions [reflect] and [msplit] witness an isomorphism between the
+   type ['a m] and the type [unit -> ('a * 'a m) option]. *)
+
+let reflect (o : unit -> ('a * 'a m) option) : 'a m =
+  delay (fun () ->
+    match o() with
+    | None ->
+        fail
+    | Some (x, m) ->
+        choose (return x) m
+  )
+
+let msplit (m : 'a m) : unit -> ('a * 'a m) option =
+  fun () ->
+    m.compute
+      (fun x f -> Some (x, reflect f))
+      (fun () -> None)
+
+let at_most_once (m : 'a m) : 'a m =
+  delay (fun () ->
+    match msplit m () with
+    | None ->
+        fail
+    | Some (x, _) ->
+        return x
+  )
+
+let rec interleave (m1 : 'a m) (m2 : 'a m) : 'a m =
+  delay (fun () ->
+    match msplit m1 () with
+    | None ->
+        m2
+    | Some (x1, m1) ->
+        choose (return x1) (interleave m2 m1)
+  )
+
+let rec (>>-) (m1 : 'a m) (f2 : 'a -> 'b m) : 'b m =
+  delay (fun () ->
+    match msplit m1 () with
+    | None ->
+        fail
+    | Some (x1, m1) ->
+        interleave (f2 x1) (m1 >>- f2)
+  )

--- a/exercises/nondet_monad_cont/wrong/return_nothing.report.txt
+++ b/exercises/nondet_monad_cont/wrong/return_nothing.report.txt
@@ -1,0 +1,12 @@
+Question 1
+  Found [return] with compatible type.
+  Found [>>=] with compatible type.
+  Found [fail] with compatible type.
+  Found [choose] with compatible type.
+  Found [sols] with compatible type.
+  Functional correctness
+    Failure: Something is wrong. The following expression:
+      
+       | sols (return 0) |> Seq.take 20 |> Seq.to_list
+      produces the following result: [[]] This is invalid. Producing the
+      following result is valid: [[0]]

--- a/exercises/nondet_monad_cont/wrong/schizophrenic_failure.log
+++ b/exercises/nondet_monad_cont/wrong/schizophrenic_failure.log
@@ -1,0 +1,2 @@
+Learnocaml v.0.10 running.
+[ Loading the prelude. ][K[ Preparing the test environment. ][K[ Loading your code. ][K[ Loading the solution. ][K[ Preparing to launch the tests. ][K[ Launching the test bench. ][K.                              - Failure - 0 points

--- a/exercises/nondet_monad_cont/wrong/schizophrenic_failure.ml
+++ b/exercises/nondet_monad_cont/wrong/schizophrenic_failure.ml
@@ -1,0 +1,71 @@
+let return (x : 'a) : 'a m =
+  let compute s f =
+    (* wrong and very weird: call both success continuation and
+       failure continuation, keep only one result *)
+    let answer1, answer2 = s x f, f() in
+    answer2
+  in
+  { compute }
+
+let (>>=) (m1 : 'a m) (f2 : 'a -> 'b m) : 'b m =
+  let compute s f = m1.compute (fun x f' -> (f2 x).compute s f') f in
+  { compute }
+
+let fail : 'a m =
+  let compute s f = f() in
+  { compute }
+
+let choose (m1 : 'a m) (m2 : 'a m) : 'a m =
+  let compute s f = m1.compute s (fun () -> m2.compute s f) in
+  { compute }
+
+let sols (m : 'a m) : 'a Seq.t =
+  fun () ->
+    m.compute
+      (fun x f -> Seq.Cons (x, f))
+      (fun () -> Seq.Nil)
+
+(* The functions [reflect] and [msplit] witness an isomorphism between the
+   type ['a m] and the type [unit -> ('a * 'a m) option]. *)
+
+let reflect (o : unit -> ('a * 'a m) option) : 'a m =
+  delay (fun () ->
+    match o() with
+    | None ->
+        fail
+    | Some (x, m) ->
+        choose (return x) m
+  )
+
+let msplit (m : 'a m) : unit -> ('a * 'a m) option =
+  fun () ->
+    m.compute
+      (fun x f -> Some (x, reflect f))
+      (fun () -> None)
+
+let at_most_once (m : 'a m) : 'a m =
+  delay (fun () ->
+    match msplit m () with
+    | None ->
+        fail
+    | Some (x, _) ->
+        return x
+  )
+
+let rec interleave (m1 : 'a m) (m2 : 'a m) : 'a m =
+  delay (fun () ->
+    match msplit m1 () with
+    | None ->
+        m2
+    | Some (x1, m1) ->
+        choose (return x1) (interleave m2 m1)
+  )
+
+let rec (>>-) (m1 : 'a m) (f2 : 'a -> 'b m) : 'b m =
+  delay (fun () ->
+    match msplit m1 () with
+    | None ->
+        fail
+    | Some (x1, m1) ->
+        interleave (f2 x1) (m1 >>- f2)
+  )

--- a/exercises/nondet_monad_cont/wrong/schizophrenic_failure.report.txt
+++ b/exercises/nondet_monad_cont/wrong/schizophrenic_failure.report.txt
@@ -1,0 +1,12 @@
+Question 1
+  Found [return] with compatible type.
+  Found [>>=] with compatible type.
+  Found [fail] with compatible type.
+  Found [choose] with compatible type.
+  Found [sols] with compatible type.
+  Functional correctness
+    Failure: Something is wrong. The following expression:
+      
+       | sols (return 0) |> Seq.take 20 |> Seq.to_list
+      produces the following result: [[]] This is invalid. Producing the
+      following result is valid: [[0]]

--- a/exercises/nondet_monad_cont/wrong/schizophrenic_success.log
+++ b/exercises/nondet_monad_cont/wrong/schizophrenic_success.log
@@ -1,0 +1,2 @@
+Learnocaml v.0.10 running.
+[ Loading the prelude. ][K[ Preparing the test environment. ][K[ Loading your code. ][K[ Loading the solution. ][K[ Preparing to launch the tests. ][K[ Launching the test bench. ][K.                              - Failure - 1 points

--- a/exercises/nondet_monad_cont/wrong/schizophrenic_success.ml
+++ b/exercises/nondet_monad_cont/wrong/schizophrenic_success.ml
@@ -1,0 +1,71 @@
+let return (x : 'a) : 'a m =
+  let compute s f =
+    (* wrong and very weird: call both success continuation and
+       failure continuation, keep only one result *)
+    let answer1, answer2 = s x f, f() in
+    answer1
+  in
+  { compute }
+
+let (>>=) (m1 : 'a m) (f2 : 'a -> 'b m) : 'b m =
+  let compute s f = m1.compute (fun x f' -> (f2 x).compute s f') f in
+  { compute }
+
+let fail : 'a m =
+  let compute s f = f() in
+  { compute }
+
+let choose (m1 : 'a m) (m2 : 'a m) : 'a m =
+  let compute s f = m1.compute s (fun () -> m2.compute s f) in
+  { compute }
+
+let sols (m : 'a m) : 'a Seq.t =
+  fun () ->
+    m.compute
+      (fun x f -> Seq.Cons (x, f))
+      (fun () -> Seq.Nil)
+
+(* The functions [reflect] and [msplit] witness an isomorphism between the
+   type ['a m] and the type [unit -> ('a * 'a m) option]. *)
+
+let reflect (o : unit -> ('a * 'a m) option) : 'a m =
+  delay (fun () ->
+    match o() with
+    | None ->
+        fail
+    | Some (x, m) ->
+        choose (return x) m
+  )
+
+let msplit (m : 'a m) : unit -> ('a * 'a m) option =
+  fun () ->
+    m.compute
+      (fun x f -> Some (x, reflect f))
+      (fun () -> None)
+
+let at_most_once (m : 'a m) : 'a m =
+  delay (fun () ->
+    match msplit m () with
+    | None ->
+        fail
+    | Some (x, _) ->
+        return x
+  )
+
+let rec interleave (m1 : 'a m) (m2 : 'a m) : 'a m =
+  delay (fun () ->
+    match msplit m1 () with
+    | None ->
+        m2
+    | Some (x1, m1) ->
+        choose (return x1) (interleave m2 m1)
+  )
+
+let rec (>>-) (m1 : 'a m) (f2 : 'a -> 'b m) : 'b m =
+  delay (fun () ->
+    match msplit m1 () with
+    | None ->
+        fail
+    | Some (x1, m1) ->
+        interleave (f2 x1) (m1 >>- f2)
+  )

--- a/exercises/nondet_monad_cont/wrong/schizophrenic_success.report.txt
+++ b/exercises/nondet_monad_cont/wrong/schizophrenic_success.report.txt
@@ -1,0 +1,19 @@
+Question 1
+  Found [return] with compatible type.
+  Found [>>=] with compatible type.
+  Found [fail] with compatible type.
+  Found [choose] with compatible type.
+  Found [sols] with compatible type.
+  Functional correctness
+    Success 1: The code seems correct. Tested 2411 scenarios.
+  Laziness
+    Failure: Some computations take place too early. The following
+             expression:
+      
+       | Seq.map snapshot sols (choose (tick (return 0)) (tick (return 0)))
+       | |> Seq.take 20
+       | |> Seq.to_list
+      produces the following result: [[((* value: *) 0, (* work: *) 2); ((*
+      value: *) 0, (* work: *) 3)]] This is invalid. Producing the following
+      result is valid: [[((* value: *) 0, (* work: *) 1); ((* value: *) 0, (*
+      work: *) 2)]]

--- a/exercises/nondet_monad_cont/wrong/template.log
+++ b/exercises/nondet_monad_cont/wrong/template.log
@@ -1,0 +1,2 @@
+Learnocaml v.0.10 running.
+[ Loading the prelude. ][K[ Preparing the test environment. ][K[ Loading your code. ][K[ Loading the solution. ][K[ Preparing to launch the tests. ][K[ Launching the test bench. ][K.                              - Failure - 0 points

--- a/exercises/nondet_monad_cont/wrong/template.ml
+++ b/exercises/nondet_monad_cont/wrong/template.ml
@@ -1,0 +1,49 @@
+let return (x : 'a) : 'a m =
+  (* TO DO: Define this function. *)
+  raise TODO
+
+let (>>=) (m1 : 'a m) (m2 : 'a -> 'b m) : 'b m =
+  (* TO DO: Define this function. *)
+  raise TODO
+
+let fail : 'a m =
+  (* TO DO: Define this constant. (Delete the whole line.) *)
+  delay (fun () -> raise TODO)
+
+let choose (m1 : 'a m) (m2 : 'a m) : 'a m =
+  (* TO DO: Define this function. *)
+  raise TODO
+
+let sols (m : 'a m) : 'a Seq.t =
+  (* TO DO: Define this function. *)
+  raise TODO
+
+let reflect (o : unit -> ('a * 'a m) option) : 'a m =
+  delay (fun () ->
+    match o() with
+    | None ->
+        (* TO DO: Complete this definition. *)
+        raise TODO
+    | Some (x, m) ->
+        (* TO DO: Complete this definition. *)
+        raise TODO
+  )
+
+let msplit (m : 'a m) : unit -> ('a * 'a m) option =
+  fun () ->
+    m.compute
+      (* TO DO: Complete this definition. *)
+      (fun x f -> raise TODO)
+      (fun  () -> raise TODO)
+
+let at_most_once (m : 'a m) : 'a m =
+  (* TO DO: Define this function. *)
+  raise TODO
+
+let rec interleave (m1 : 'a m) (m2 : 'a m) : 'a m =
+  (* TO DO: Define this function. *)
+  raise TODO
+
+let rec (>>-) (m1 : 'a m) (m2 : 'a -> 'b m) : 'b m =
+  (* TO DO: Define this function. *)
+  raise TODO

--- a/exercises/nondet_monad_cont/wrong/template.report.txt
+++ b/exercises/nondet_monad_cont/wrong/template.report.txt
@@ -1,0 +1,8 @@
+Question 1
+  Found [return] with compatible type.
+  Found [>>=] with compatible type.
+  Found [fail] with compatible type.
+  Found [choose] with compatible type.
+  Found [sols] with compatible type.
+  Functional correctness
+    Failure: Not yet implemented.

--- a/exercises/nondet_monad_defun/AUTHOR
+++ b/exercises/nondet_monad_defun/AUTHOR
@@ -1,0 +1,1 @@
+François Pottier

--- a/exercises/nondet_monad_defun/Makefile
+++ b/exercises/nondet_monad_defun/Makefile
@@ -1,0 +1,2 @@
+LIB   := $(shell cd ../lib && pwd)
+include $(LIB)/Makefile

--- a/exercises/nondet_monad_defun/TODO
+++ b/exercises/nondet_monad_defun/TODO
@@ -1,0 +1,9 @@
+-- about this exercise ---------------------------------------------------------
+
+* Copy every change from nondet_monad_seq to nondet_monad_defun.
+
+* Add a link to Pottier-Gauthier.
+
+-- ocaml questions -------------------------------------------------------------
+
+-- learn-ocaml questions -------------------------------------------------------

--- a/exercises/nondet_monad_defun/TODO
+++ b/exercises/nondet_monad_defun/TODO
@@ -2,8 +2,6 @@
 
 * Copy every change from nondet_monad_seq to nondet_monad_defun.
 
-* Add a link to Pottier-Gauthier.
-
 -- ocaml questions -------------------------------------------------------------
 
 -- learn-ocaml questions -------------------------------------------------------

--- a/exercises/nondet_monad_defun/descr.md
+++ b/exercises/nondet_monad_defun/descr.md
@@ -518,7 +518,9 @@ This is in fact arguably a rather natural way of discovering this
 implementation, as it could otherwise be difficult to *guess* the
 definitions of the algebraic data types `_ failure`,
 `(_, _) success`, and `_ m`.
-A paper by Pottier and Gauthier
+The paper
+**Polymorphic typed defunctionalization and concretization**
+[(Pottier and Gauthier, 2006)](http://gallium.inria.fr/~fpottier/publis/fpottier-gauthier-hosc.pdf)
 explains how defunctionalization
 gives rise to a generalized algebraic data type
 and an `apply` function

--- a/exercises/nondet_monad_defun/descr.md
+++ b/exercises/nondet_monad_defun/descr.md
@@ -1,0 +1,528 @@
+# Implementing Nondeterminism as an Abstract Machine
+
+In this exercise, we build an implementation of the nondeterminism
+monad. This monad admits several possible implementations. The one
+that we choose here can be described as an *abstract machine* that
+interprets a piece of *code* and uses two auxiliary stack-like data
+structures, namely a *success continuation*, and a *failure continuation*.
+Each of these three data structures is described by a generalized
+algebraic data type.
+
+This implementation can be viewed as a defunctionalized version
+of the continuation-based implementation studied in
+<a href="" onclick="top.location='/exercises/nondet_monad_cont/';">another exercise</a>.
+The underlying algorithm is exactly the same,
+but whereas the continuation-based implementation represents
+code and continuations as first-class functions,
+this implementation represents them as data structures.
+
+We suggest doing the other exercise first
+and attempting this exercise next.
+
+## The Nondeterminism Monad
+
+When searching for the solution of a problem, one must typically
+explore multiple choices. If a series of choices lead to a failure
+(a dead end), then one must backtrack and explore another avenue.
+
+There are a number of ways in which nondeterminism and backtracking
+can be implemented. Regardless of which implementation mechanism is
+chosen, it is desirable to hide it behind an abstraction barrier and
+present the end user with **a simple API for constructing an executing
+nondeterministic computations**.
+
+This API is known as the **nondeterminism monad**. It offers the
+following key elements:
+
+* A type `'a m`, the type of computations that yield results of type
+ `'a`.
+
+* A number of constructor functions for constructing computations,
+  such as `fail: 'a m`, which represents failure, and `choose: 'a m
+  -> 'a m -> 'a m`, which expresses a nondeterministic choice
+  between two computations.
+
+* A single observation function, `sols: 'a m -> 'a Seq.t`, which
+  converts a computation to a sequence of results, thereby allowing
+  the user to execute this computation and observe its results. The
+  name `sols` stands for `solutions`.
+
+A monad can be thought of as a **mini-programming language** where
+computations are first-class citizens: we have a type of
+computations, ways of building computations, and a way of executing
+computations.
+
+A computation in the nondeterminism monad can produce zero, one, or
+more results. Indeed, a computation that fails produces zero
+results. A computation that succeeds normally produces one result.
+A computation that uses `choose` can produce more than one result.
+It is in fact possible to construct computations that produce an
+infinite number of results!
+
+Thus, a useful way to think of a computation is as **a sequence of
+results**, that is, a sequence of results.
+
+Because of this remark, one might be tempted to define the type `'a
+m` as a synonym for `'a Seq.t`, the type of sequences of values of
+type `'a`. However, although it is possible to represent a
+computation internally as a sequence (and we will do so in this
+exercise), this is not necessarily the best implementation
+technique. Thus, we prefer to make the API more flexible by viewing
+`'a m` as an abstract type and by offering an observation function,
+`sols`, which converts a computation to a sequence.
+
+## The Nondeterminism Monad's API
+
+The signature, or API, of the nondeterminism monad is as follows:
+
+```
+  (* Type. *)
+  type 'a m
+
+  (* Constructor functions. *)
+  val return: 'a -> 'a m
+  val (>>=): 'a m -> ('a -> 'b m) -> 'b m
+  val fail: 'a m
+  val choose: 'a m -> 'a m -> 'a m
+  val delay: (unit -> 'a m) -> 'a m
+  val at_most_once: 'a m -> 'a m
+  val interleave: 'a m -> 'a m -> 'a m
+  val (>>-): 'a m -> ('a -> 'b m) -> 'b m
+
+  (* Observation function. *)
+  val sols: 'a m -> 'a Seq.t
+```
+
+As explained above, a value of type `'a m` is **a description of a
+computation**, which, once executed, produces a sequence of results
+of type `'a`.
+
+To execute a computation `m`, one must first convert it to a
+sequence of type `'a Seq.t`, whose elements can then be demanded,
+one by one. (More information on the module `Seq` is given below.)
+This conversion is performed by the observation function `sols`.
+
+The call `sols m` typically terminates in constant time; the actual
+computation described by `m` takes place only when the elements of
+the sequence `sols m` are demanded, and only insofar as necessary to
+produce the elements that are demanded. For instance, applying
+`Seq.head` to the sequence `sols m` forces the computation to
+proceed up to the point where it is able to produce its first
+result.
+
+The constructor functions `return` and `(>>=)` exist in all monads.
+(They are also known as `return` and `bind`.) `return` constructs a
+trivial computation, which does nothing except return a value,
+whereas `(>>=)` constructs the sequential composition of two
+computations. Together, they allow constructing the sequential
+composition of an arbitrary number of computations.
+
+* The computation `return v` succeeds exactly once with the value
+  `v`. In other words, the sequence of values that it produces is
+  the singleton sequence composed of just `v`.
+
+* The computation `m1 >>= m2` is the sequential composition of the
+  computations `m1` and `m2`. This composition operator is
+  asymmetric: whereas its first argument `m1` is a computation of
+  type `'a m`, its second argument `m2` is a function of type `a ->
+  'b m`. Every value `x` produced by `m1` is passed to `m2`,
+  yielding a computation `m2 x`. The sequence of values produced by
+  `m1 >>= m2` is the concatenation of the sequences of values
+  produced by the computations `m2 x`, where `x` ranges over the
+  values produced by `m1`.
+
+The constructor functions `fail` and `choose` are specific of the
+nondeterminism monad. `fail` can be thought of as a 0-ary
+disjunction, whereas `choose` is a binary disjunction. Together,
+they allow constructing the disjunction of an arbitrary number of
+computations.
+
+* The computation `fail` returns no result. In other words, it
+  produces an empty sequence of values.
+
+* The sequence of values produced by `choose m1 m2` is the
+  concatenation of the sequences of values produced by `m1`
+  and by `m2`.
+
+The constructor function `delay` is used to delay the construction
+of a computation until the moment where this computation must be
+executed. Indeed, a difficulty that arises in a strict programming
+language, such as OCaml, is that the arguments passed to constructor
+functions, such as `return` and `choose`, are evaluated immediately,
+at construction time. For instance, when one writes `choose e1 e2`,
+both of the OCaml expressions `e1` and `e2` are evaluated before
+`choose` is invoked. If the evaluation of `e2` performs nontrivial
+work, then this work arguably takes place too early: indeed, there
+should be no need to evaluate `e2` until all of the values produced
+by `e1` have been demanded. To remedy this, one may write `choose e1
+(delay (fun () -> e2))`. There, the expression `e2` is placed in the
+body of an anonymous function, so `e2` is not evaluated immediately.
+This anonymous function, whose type is `unit -> 'a m`,
+is converted by `delay` to a computation of type `'a m`.
+This conversion requires no serious work;
+it is performed in constant time.
+An intuitive reason why this is possible is that the type `'a m`
+represents a *suspended* computation already,
+so the type `unit -> 'a m` represents a *suspended suspended*
+computation, which is essentially the same thing; these types
+are interconvertible at no cost.
+
+The computations `e` and `delay (fun () -> e)` produce the same
+sequence of results. The only difference between them is the time at
+which the evaluation of `e` takes place: either immediately, or only
+when the first result is demanded.
+
+It is worth noting that in a lazy language, such as Haskell, there
+is no need for `delay`. In such a language, when one writes `choose
+e1 e2`, the expressions `e1` and `e2` are *not* evaluated
+immediately: they are evaluated only when their value is demanded.
+Thus, the fact that `e2` need not be evaluated until all of the
+values produced by `e1` have been demanded goes without saying. The
+fact that there is no need for explicit uses of `delay` is arguably
+a strength of lazy languages. At the same time, the fact that it is
+not obvious where laziness plays a crucial role is arguably a
+weakness of lazy languages. In OCaml, in contrast, the explicit use
+of `delay` can be verbose, but helps understand what is going on.
+
+The constructor function `at_most_once` constructs a computation
+that succeeds at most once. If `m` fails, then `at_most_once m`
+fails as well. If `m` produces a result `x`, possibly followed with
+more results, then `at_most_once m` produces just the result `x`,
+and no more. This combinator can be used to commit to a result and
+prevent any other choices from being explored. In other words, it
+limits the amount of backtracking that takes place.
+
+The constructor function `interleave` has the same type as `choose`.
+It is a *fair disjunction* operator. An ordinary disjunction `choose
+m1 m2` gives priority to its left branch: it first lets `e1` produce
+as many results as it wishes, then gives control to `e2`. This can
+be problematic: if `e1` produces a large number of results, then
+`e2` is tried very late. At an extreme, if `e1` produces an infinite
+number of results, then `e2` is never tried. For instance, supposing
+that `evens` produces the infinite sequence `0, 2, 4, ...` and
+`odds` produces the infinite sequence `1, 3, 5, ...`,
+the disjunction `choose evens odds` is equivalent to just `evens`,
+which seems counter-intuitive and undesirable. In contrast,
+`interleave` is defined in such a way that `interleave evens odd`
+produces the infinite sequence `0, 1, 2, 3, 4, 5, ...`.
+It is *fair* in the sense that each branch in turn is allowed
+to produce a result.
+
+The constructor function `(>>-)` has the same type as `(>>=)`.
+It is a *fair sequencing* operator.
+Indeed, a problem with ordinary sequencing `(>>=)` is that
+it gives rise to ordinary (unfair) disjunctions.
+To see this, suppose that the left-hand argument of `(>>=)`
+is a computation that produces `x` as its first result,
+followed with a computation `m1` that may produce more results.
+Thus, this left-hand argument is equivalent to
+`choose (return x) m1`.
+When we sequentially compose it with a computation `m2`,
+we obtain
+`(choose (return x) m1) >>= m2`,
+which is equivalent to
+`choose (return x >>= m2) (m1 >>= m2)`,
+which itself is the same as
+`choose (m2 x) (m1 >>= m2)`.
+We are faced with an ordinary (unfair) disjunction.
+The problem, again, is that if `m2 x` produces an
+infinite number of results, then `m1 >>= m2`
+is never executed.
+To remedy this problem,
+the fair sequencing operator `(>>-)`
+is defined in such a way that
+`choose (return x) m1 >>- m2`
+is equivalent to
+`interleave (m2 x) (m1 >>- m2)`.
+Thus, it gives rise to a fair disjunction.
+
+## The `Seq` API
+
+The type of **on-demand sequences** is defined in a module named `Seq`.
+Beginning with version 4.07,
+this module is part of OCaml's standard library.
+
+```
+module Seq : sig
+
+  type 'a t = unit -> 'a node
+
+  and +'a node =
+  | Nil
+  | Cons of 'a * 'a t
+
+  val nil : 'a t
+  val cons: 'a -> 'a t -> 'a t
+  val singleton: 'a -> 'a t
+
+  val map: ('a -> 'b) -> 'a t -> 'b t
+  val concat: 'a t -> 'a t -> 'a t
+  val flatten: 'a t t -> 'a t
+
+  val take: int -> 'a t -> 'a t
+
+  val head: 'a t -> 'a option
+
+  val of_list: 'a list -> 'a t
+  val to_list: 'a t -> 'a list
+
+end
+```
+
+This data type is closely related to the algebraic data type of lists.
+Indeed, if instead of `unit -> 'a node` one had written just `'a node`,
+then this data type would have been isomorphic to the type of lists.
+
+The presence of `unit -> ...` indicates that a sequence is in fact a function.
+Calling this function, by applying it to the value `()`, amounts to requesting
+the head of the sequence. This head can be either `Nil`, which means that the
+sequence is empty, or `Cons (x, xs)`, which means that the first element of
+the sequence is `x` and the remaining elements form another sequence `xs`. It
+is worth noting that `xs` is itself a function, so the elements of the
+sequence `xs` need not be explicitly computed until `xs` is applied.
+
+Sequences are closely related to *iterators* in object-oriented languages,
+such as C++ and Java. Yet, sequences are much simpler than iterators, for
+two reasons:
+
+* they involve no mutable state;
+
+* they are just as easy to construct and to use as ordinary lists.
+
+The functions `nil`, `cons`, and `singleton` are constructor functions.
+
+The functions `map`, `concat`, `flatten` are analogues for sequences
+of the standard list functions `List.map`, `(@)`, and
+`List.flatten`.
+
+The function `Seq.take` truncates a sequence at a certain length:
+`Seq.take n xs` is a sequence that begins like `xs` but has at most
+`n` elements.
+
+The function `Seq.head` demands the first element of a sequence. If
+the sequence begins with an element `x`, then `Some x` is returned;
+otherwise, `None` is returned. This forces enough computation to
+take place so as to be able to produce the first element of the
+sequence.
+
+The functions `Seq.of_list` and `Seq.to_list` convert between lists
+and sequences, both ways. One must keep in mind that applying
+`Seq.to_list` to a sequence `xs` causes all of its elements to be
+demanded: that is, it forces all of the suspended computations to
+take place. In particular, if `xs` is an infinite sequence, then
+`Seq.to_list xs` does not terminate.
+
+## Data Structures for Continuations and Computations
+
+In this exercise, we implement an abstract machine that manipulates three data
+structures: a **computation**, a **failure continuation**, and a **success
+continuation**. The idea is, in general, the computation indicates what to do
+next; in the case where the computation is `fail`, the failure continuation
+indicates what to do next; in the case where the computation is `return x`,
+the success continuation indicates what to do next.
+
+Each of these three data structures is described by a generalized algebraic
+data type. We now give the definitions of these data types. (These definitions
+can in fact be *deduced* from the solution of the
+<a href="" onclick="top.location='/exercises/nondet_monad_cont/';">companion exercise</a>,
+by defunctionalization, but we leave this story for another time.)
+
+The type `'a m` of **computations** is defined as follows:
+
+```
+type 'a m =
+| MDelay:               (unit -> 'a m) -> 'a m
+| MReturn:                          'a -> 'a m
+| MBind:           'a m * ('a -> 'b m) -> 'b m
+| MFail:                                  'a m
+| MChoose:                 'a m * 'a m -> 'a m
+| MReflect: ('a * 'a m) option failure -> 'a m
+```
+
+The data constructors `MDelay`, `MReturn`, `MBind`, `MFail`, and `MChoose`
+correspond directly to the constructor functions `delay`, `return`, `>>=`,
+`fail`, and `choose`. In other words, a computation is represented internally
+by its syntax.
+
+If `f` is a failure continuation whose answer type is `('a * 'a m) option`,
+then `MReflect f` is a computation. In other words, the data constructor
+`MReflect` allows disguising such a failure continuation as a computation.
+This is useful in the implementation of the operation `msplit`, which
+itself is used in Question 2-4, as in the
+<a href="" onclick="top.location='/exercises/nondet_monad_cont/';">companion exercise</a>.
+
+The type `'answer failure` of **failure continuations** is defined as follows:
+
+```
+and 'answer failure =
+| FChoose:
+    (* m2: *) 'a m *
+    (* s : *) ('a, 'answer) success *
+    (* f : *) 'answer failure ->
+              'answer failure
+| FSols:
+    _ Seq.node failure
+| FSplit:
+    _ option failure
+```
+
+Thus, a failure continuation is a data structure. This data structure can be
+*interpreted* as a function of type `unit -> 'answer` by the function
+`apply_failure`, whose type is
+`'answer failure -> unit -> 'answer`,
+and whose code you have to complete as part of this exercise.
+There are three data constructors:
+
+* `FChoose (m2, s, f)` records the fact that a choice of the form `choose m1
+  m2` has been entered. The right-hand branch `m2` as well as the current
+  success and failure continuations `s` and `f` are recorded, so as to allow
+  the computation to continue if and after the left-hand branch `m1` fails.
+
+* `FSols` records the fact that this computation is executed by the
+  observation function `sols`. When interpreted as a function, this
+  failure continuation returns `Seq.Nil`.
+
+* `FSplit` records the fact that this computation is executed by the
+  observation function `msplit`. When interpreted as a function, this
+  failure continuation returns `None`.
+
+The type `('a, 'answer) success` of **success continuations** is defined
+as follows:
+
+```
+and ('a, 'answer) success =
+| SBind:
+    (* m2: *) ('a -> 'b m) *
+    (* s : *) ('b, 'answer) success ->
+              ('a, 'answer) success
+| SSols:
+    ('a, 'a Seq.node) success
+| SSplit:
+    ('a, ('a * 'a m) option) success
+```
+
+Thus, a success continuation is a data structure. This data structure can be
+*interpreted* as a function of type `'a -> 'answer failure -> 'answer`
+by the function `apply_success`,
+whose type is `('a, 'answer) success -> 'a -> 'answer failure -> 'answer`,
+and whose code you have to complete as part of this exercise.
+There are three data constructors:
+
+* `SBind (m2, s)` records the fact that a sequence of the form `m1 >>= m2` has
+  been entered. The right-hand side of the sequence `m2` as well as the
+  current success continuation `s` are recorded so as to allow the computation
+  to continue if (and every time) `m1` produces a result.
+
+* `SSols` records the fact that this computation is executed by the
+  observation function `sols`. When interpreted as a function, this
+  success continuation returns an answer of the form `Seq.Cons (_, _)`.
+
+* `SSplit` records the fact that this computation is executed by the
+  observation function `msplit`. When interpreted as a function, this
+  success continuation returns an answer of the form `Some (_, _)`.
+
+The data types `'a m`, `'answer failure` and `('a, 'answer) success` are
+mutually recursive. Thus, the three functions which interpret these data
+types, namely `compute`, `apply_failure`, and `apply_success`, are
+mutually recursive as well.
+
+## Implementing the Abstract Machine
+
+The four constructor functions `return`, `(>>=)`, `fail`, and `choose`
+have been implemented for you already. They are trivial anyway.
+
+**Question 1.**
+Complete the definitions of the functions
+`apply_failure`, `apply_success`, and `compute`.
+Then, implement the observation function `sols`.
+
+*Note.* The automated grading system first tests whether your code
+is functionally correct. To do so, it builds a computation using the
+four constructor functions, converts it to a sequence via `sols`,
+and tests whether this produces the expected sequence of results.
+Then, it tests whether your code is lazy, that is, whether each
+result is computed as late as possible. To do so, it uses a
+constructor function `tick: 'a m -> 'a m` whose effect is as
+follows: the computation `tick m` produces the same sequence of
+results as the computation `m`, and, when executed, increments a
+global counter named `work`. Thus, by executing computations that
+contain `tick`s, the automated grading system can tell when
+computations are executed. For instance, demanding just the first
+result of the computation
+`choose (tick (return 0)) (tick (return 1))` should cause `work` to
+be incremented just once, not twice.
+
+*Note.* The automated grading system for Question 1 does not exercise the
+cases for `FSplit`, `SSplit` and `MReflect` in the abstract machine. In order
+to ensure that your code deals with these cases correctly, you must continue
+this exercise and pass Questions 2-4 as well.
+
+As in the continuation-based implementation described in a
+<a href="" onclick="top.location='/exercises/nondet_monad_cont/';">companion exercise</a>,
+before attacking Questions 2-4,
+we must define an auxiliary function, `msplit`.
+
+The need for `msplit` arises from the following remark. When executed, a
+computation of type `'a m` produces a sequence of results. Such a sequence
+must be either empty or nonempty, and in the latter case, it must have a first
+element and a remainder. If a computation *was* just a sequence (that is, if
+the type `'a m` was a synonym for `'a Seq.t`), then we could distinguish these
+two situations just by performing a case analysis.
+
+Because we have defined the type `'a m` in a different way, a direct case
+analysis is impossible. Instead, the idea is to define a function `msplit`
+that *converts* from the type `'a m` to the type `unit -> ('a * 'a m) option`.
+This opens the door to a case analysis. In short, `msplit` allows us to
+perform case analysis on a computation *as if* it was a sequence, even though
+its internal representation is different.
+
+**Question X.** (Not graded.)
+Complete the implementation of the auxiliary function `msplit.`
+
+Once `msplit` is available,
+Questions 2-4 are answered in exactly the same way as in the
+<a href="" onclick="top.location='/exercises/nondet_monad_cont/';">companion exercise</a>.
+
+**Question 2.** Implement the constructor function `at_most_once`.
+
+*Hint.* Use `msplit` to determine if the computation at hand fails or produces
+at least one result. In the first case, recall that `at_most_once fail` is
+supposed to behave like `fail`. In the second case, recall that
+`at_most_once (choose (return x) m)` is supposed to behave like
+`return x`.
+
+*Hint.* Use `delay` to ensure that the case analysis is performed when
+the computation `at_most_once m` is *executed*, not when it is *built*.
+
+**Question 3.** Implement the constructor function `interleave`.
+
+*Hint.* Again, use `delay` and `msplit` in an appropriate manner.
+Then, ask yourself how `interleave fail m2` is supposed to behave,
+and how `interleave (choose (return x1) m1) m2` is supposed
+to behave.
+
+**Question 4.** Implement the constructor function `(>>-)`.
+
+*Hint.* Again, use `delay` and `msplit` in an appropriate manner.
+Then, ask yourself how `fail >>- m2` is supposed to behave,
+and how `(choose (return x1) m1) >>- m2` is supposed
+to behave.
+
+## Notes
+
+This implementation can be obtained from the continuation-based implementation studied in
+<a href="" onclick="top.location='/exercises/nondet_monad_cont/';">another exercise</a>
+in a systematic manner by performing
+[defunctionalization](https://en.wikipedia.org/wiki/Defunctionalization).
+This is in fact arguably a rather natural way of discovering this
+implementation, as it could otherwise be difficult to *guess* the
+definitions of the algebraic data types `_ failure`,
+`(_, _) success`, and `_ m`.
+A paper by Pottier and Gauthier
+explains how defunctionalization
+gives rise to a generalized algebraic data type
+and an `apply` function
+in the transformed program.
+Here, the process gives rise to three generalized algebraic data types
+and three `apply` functions, because we defunctionalize computations,
+success continuations, and failure continuations independently.

--- a/exercises/nondet_monad_defun/descr.md
+++ b/exercises/nondet_monad_defun/descr.md
@@ -528,3 +528,7 @@ in the transformed program.
 Here, the process gives rise to three generalized algebraic data types
 and three `apply` functions, because we defunctionalize computations,
 success continuations, and failure continuations independently.
+
+One potential advantage of the defunctionalized version is the fact that it
+can be implemented in a programming language that does not support first-class
+functions, such as C.

--- a/exercises/nondet_monad_defun/master.ml
+++ b/exercises/nondet_monad_defun/master.ml
@@ -1,0 +1,221 @@
+(* The following four constructor functions are implemented already. *)
+
+let return (x : 'a) : 'a m =
+  MReturn x
+
+let (>>=) (m1 : 'a m) (m2 : 'a -> 'b m) : 'b m =
+  MBind (m1, m2)
+
+let fail : 'a m =
+  MFail
+
+let choose (m1 : 'a m) (m2 : 'a m) : 'a m =
+  MChoose (m1, m2)
+
+(* The bulk of the work is to implement an interpreter for each of the
+   data types [_ failure], [(_, _) success], and [_ m]. *)
+
+let rec apply_failure : type answer . answer failure -> unit -> answer =
+  fun f () ->
+    match f with
+    | FChoose (m2, s, f) ->
+        (* Invoked when the left branch of a choice has failed.
+           [m2] is the right branch of the choice.
+           [s] and [f] are the continuations of the choice. *)
+        (* BEGIN INCLUDE *)
+        raise TODO (* one line *)
+        (*   END INCLUDE *)
+        (* BEGIN EXCLUDE
+        compute m2 s f
+             END EXCLUDE *)
+    | FSols ->
+        (* Used at the top level of [sols].
+           Invoked when there is no result. *)
+        (* BEGIN INCLUDE *)
+        raise TODO (* one line *)
+        (*   END INCLUDE *)
+        (* BEGIN EXCLUDE
+        Seq.Nil
+             END EXCLUDE *)
+    | FSplit ->
+        (* Used at the top level of [msplit].
+           Invoked when there is no result. *)
+        (* BEGIN INCLUDE *)
+        raise TODO (* one line *)
+        (*   END INCLUDE *)
+        (* BEGIN EXCLUDE
+        None
+             END EXCLUDE *)
+
+and apply_success : type a answer .
+  (a, answer) success -> a -> answer failure -> answer
+=
+  fun s x f ->
+    match s with
+    | SBind (m2, s) ->
+        (* Invoked when the left branch of a sequence produces a result [x].
+           [m2] is the right-hand side of the sequence.
+           [s] is the success continuation of the sequence. *)
+        (* BEGIN INCLUDE *)
+        raise TODO (* one line *)
+        (*   END INCLUDE *)
+        (* BEGIN EXCLUDE
+        compute (m2 x) s f
+             END EXCLUDE *)
+    | SSols ->
+        (* Used at the top level of [sols].
+           Invoked when the computation produces a result [x]. *)
+        (* Hint: construct a sequence whose head is [x] and whose
+                 tail is [f], converted to the type of a sequence.
+                 There is an easy way of performing this conversion. *)
+        (* BEGIN INCLUDE *)
+        raise TODO (* one line *)
+        (*   END INCLUDE *)
+        (* BEGIN EXCLUDE
+        Seq.Cons (x, apply_failure f)
+             END EXCLUDE *)
+    | SSplit ->
+        (* Used at the top level of [msplit].
+           Invoked when the computation produces a result [x]. *)
+        (* Hint: construct an optional-pair whose first component is [x]
+                 and whose second component is [f], converted to the type
+                 of a computation. There is an easy way of performing this
+                 conversion.  *)
+        (* BEGIN INCLUDE *)
+        raise TODO (* one line *)
+        (*   END INCLUDE *)
+        (* BEGIN EXCLUDE
+        Some (x, MReflect f)
+             END EXCLUDE *)
+
+and compute : type a answer .
+  a m -> (a, answer) success -> answer failure -> answer
+=
+  fun m s f ->
+    match m with
+    | MDelay m ->
+        (* BEGIN INCLUDE *)
+        (* Hint: evaluate [m()] and continue. *)
+        raise TODO (* one line *)
+        (*   END INCLUDE *)
+        (* BEGIN EXCLUDE
+        compute (m()) s f
+             END EXCLUDE *)
+    | MReturn x ->
+        (* BEGIN INCLUDE *)
+        (* Hint: successfully produce the result [x]. *)
+        raise TODO (* one line *)
+        (*   END INCLUDE *)
+        (* BEGIN EXCLUDE
+        apply_success s x f
+             END EXCLUDE *)
+    | MBind (m1, m2) ->
+        (* BEGIN INCLUDE *)
+        (* Hint: enter the left-hand side [m1] with an
+                 appropriate success continuation. *)
+        raise TODO (* one line *)
+        (*   END INCLUDE *)
+        (* BEGIN EXCLUDE
+        compute m1 (SBind (m2, s)) f
+             END EXCLUDE *)
+    | MFail ->
+        (* BEGIN INCLUDE *)
+        (* Hint: fail. *)
+        raise TODO (* one line *)
+        (*   END INCLUDE *)
+        (* BEGIN EXCLUDE
+        apply_failure f ()
+             END EXCLUDE *)
+    | MChoose (m1, m2) ->
+        (* BEGIN INCLUDE *)
+        (* Hint: enter the left-hand side [m1] with an
+                 appropriate failure continuation. *)
+        raise TODO (* one line *)
+        (*   END INCLUDE *)
+        (* BEGIN EXCLUDE
+        compute m1 s (FChoose (m2, s, f))
+             END EXCLUDE *)
+    | MReflect k ->
+        (* BEGIN INCLUDE *)
+        (* We have a failure continuation [k], which was captured earlier and
+           wrapped with [MReflect] so as to pretend it is a computation. We are
+           now asked to execute this computation. Thus, we must call this
+           failure continuation, whose answer type is [('a * 'a m) option].
+           Depending on whether this yields [None] or [Some (x, m)], we must
+           behave either like [fail] or like [choose (return x) m]. *)
+        raise TODO (* five lines *)
+        (*   END INCLUDE *)
+        (* BEGIN EXCLUDE
+        match apply_failure k () with
+        | None ->
+            apply_failure f ()
+            (* inlined version of [compute fail s f] *)
+        | Some (x, m) ->
+            apply_success s x (FChoose (m, s, f))
+            (* inlined version of [compute (choose (return x) m) s f] *)
+             END EXCLUDE *)
+
+let sols (m : 'a m) : 'a Seq.t =
+(* BEGIN INCLUDE *)
+  (* TO DO: Define this function. *)
+  raise TODO (* one line *)
+(*   END INCLUDE *)
+(* BEGIN EXCLUDE
+  fun () ->
+    compute m SSols FSols
+     END EXCLUDE *)
+
+let msplit (m : 'a m) : unit -> ('a * 'a m) option =
+(* BEGIN INCLUDE *)
+  (* TO DO: Define this function. *)
+  raise TODO (* one line *)
+(*   END INCLUDE *)
+(* BEGIN EXCLUDE
+  fun () ->
+    compute m SSplit FSplit
+     END EXCLUDE *)
+
+let at_most_once (m : 'a m) : 'a m =
+(* BEGIN INCLUDE *)
+  (* TO DO: Define this function. *)
+  raise TODO
+(*   END INCLUDE *)
+(* BEGIN EXCLUDE
+  delay (fun () ->
+    match msplit m () with
+    | None ->
+        fail
+    | Some (x, _) ->
+        return x
+  )
+     END EXCLUDE *)
+
+let rec interleave (m1 : 'a m) (m2 : 'a m) : 'a m =
+(* BEGIN INCLUDE *)
+  (* TO DO: Define this function. *)
+  raise TODO
+(*   END INCLUDE *)
+(* BEGIN EXCLUDE
+  delay (fun () ->
+    match msplit m1 () with
+    | None ->
+        m2
+    | Some (x1, m1) ->
+        choose (return x1) (interleave m2 m1)
+  )
+     END EXCLUDE *)
+
+let rec (>>-) (m1 : 'a m) (m2 : 'a -> 'b m) : 'b m =
+(* BEGIN INCLUDE *)
+  (* TO DO: Define this function. *)
+  raise TODO
+(*   END INCLUDE *)
+(* BEGIN EXCLUDE
+  delay (fun () ->
+    match msplit m1 () with
+    | None ->
+        fail
+    | Some (x1, m1) ->
+        interleave (m2 x1) (m1 >>- m2)
+  )
+     END EXCLUDE *)

--- a/exercises/nondet_monad_defun/meta.json
+++ b/exercises/nondet_monad_defun/meta.json
@@ -1,0 +1,6 @@
+{
+  "learnocaml_version":"1",
+  "kind":"exercise",
+  "stars":3,
+  "title":"Implementing Nondeterminism as an Abstract Machine"
+}

--- a/exercises/nondet_monad_defun/prelude.ml
+++ b/exercises/nondet_monad_defun/prelude.ml
@@ -1,0 +1,169 @@
+(* The module [Seq] is standard as of OCaml 4.07. *)
+
+module Seq = struct
+
+  type 'a t = unit -> 'a node
+
+  and +'a node =
+  | Nil
+  | Cons of 'a * 'a t
+
+  let nil =
+    fun () -> Nil
+
+  let cons x xs =
+    fun () -> Cons (x, xs)
+
+  let singleton x =
+    cons x nil
+
+  let rec map (f : 'a -> 'b) (xs : 'a t) : 'b t =
+    fun () ->
+      match xs() with
+      | Nil ->
+          Nil
+      | Cons (x, xs) ->
+          Cons (f x, map f xs)
+
+  let rec concat (xs : 'a t) (ys : 'a t) : 'a t =
+    fun () ->
+      match xs() with
+      | Nil ->
+          ys()
+      | Cons (x, xs) ->
+          Cons (x, concat xs ys)
+
+  let rec flatten (xss : 'a t t) : 'a t =
+    fun () ->
+      match xss() with
+      | Nil ->
+          Nil
+      | Cons (xs, xss) ->
+          concat xs (flatten xss) ()
+
+  let rec take n (xs : 'a t) : 'a t =
+    if n = 0 then
+      nil
+    else
+      fun () ->
+        match xs() with
+        | Nil ->
+            Nil
+        | Cons (x, xs) ->
+            Cons (x, take (n-1) xs)
+
+  let head (xs : 'a t) : 'a option =
+    match xs() with
+    | Nil ->
+        None
+    | Cons (x, _) ->
+        Some x
+
+  let rec of_list (xs : 'a list) : 'a t =
+    fun () ->
+      match xs with
+      | [] ->
+          Nil
+      | x :: xs ->
+          Cons (x, of_list xs)
+
+  (* A word of warning: [to_list] does not terminate if it is applied
+     to an infinite sequence. Furthermore, this version of [to_list]
+     is not tail-recursive and could exhaust the stack space if it was
+     applied to a long sequence. *)
+
+  let rec to_list (xs : 'a t) : 'a list =
+    match xs() with
+    | Nil ->
+        []
+    | Cons (x, xs) ->
+        x :: to_list xs
+
+end
+
+(* A nondeterministic computation is a data structure, described by the
+   following generalized algebraic data type. *)
+
+(* A nondeterministic computation can also be interpreted as a process
+   that produces a sequence of results. This interpretation is performed
+   by the function [compute]. *)
+
+type 'a m =
+| MDelay:               (unit -> 'a m) -> 'a m
+| MReturn:                          'a -> 'a m
+| MBind:           'a m * ('a -> 'b m) -> 'b m
+| MFail:                                  'a m
+| MChoose:                 'a m * 'a m -> 'a m
+| MReflect: ('a * 'a m) option failure -> 'a m
+
+(* A failure continuation is a data structure, described by the following
+   generalized algebraic data type. *)
+
+(* A failure continuation can also be interpreted as a function that takes
+   no argument and returns a final answer. This interpretation is performed
+   by the function [apply_failure]. *)
+
+(* An [FChoose] entry is known in the logic programming literature as a
+   choice point. Each [FChoose] entry contains a pointer [f] to another
+   failure continuation, so a failure continuation can be viewed as a
+   stack of choice points, represented in memory as a linked list. One
+   of [FSols] and [FSplit] serves to indicate the bottom of the stack. *)
+
+and 'answer failure =
+| FChoose:
+    (* m2: *) 'a m *
+    (* s : *) ('a, 'answer) success *
+    (* f : *) 'answer failure ->
+              'answer failure
+| FSols:
+    _ Seq.node failure
+| FSplit:
+    _ option failure
+
+(* A success continuation is a data structure, described by the following
+   generalized algebraic data type. *)
+
+(* A success continuation can also be interpreted as a function that takes
+   one argument (a result) and returns a final answer. This interpretation
+   is performed by the function [apply_success]. *)
+
+(* Each [SBind] entry contains a pointer [s] to another success continuation,
+   so a success continuation can be viewed as a stack, represented in memory
+   as a linked list. One of [SSols] and [SSplit] serves to indicate the bottom
+   of the stack. *)
+
+and ('a, 'answer) success =
+| SBind:
+    (* m2: *) ('a -> 'b m) *
+    (* s : *) ('b, 'answer) success ->
+              ('a, 'answer) success
+| SSols:
+    ('a, 'a Seq.node) success
+| SSplit:
+    ('a, ('a * 'a m) option) success
+
+(* Implementing this constructor function is immediate. *)
+
+let delay (m : unit -> 'a m) : 'a m =
+  MDelay m
+
+(* The effect of executing the computation [tick m] is to first increment the
+   global counter [work], then execute the computation [m]. *)
+
+(* The grading code uses these operations in order to check that computations
+   are executed on demand, that is, as late as possible. *)
+
+let work =
+  ref 0
+
+let reset() =
+  work := 0
+
+let tick (m : 'a m) : 'a m =
+  delay (fun () ->
+    work := !work + 1;
+    m
+  )
+
+let snapshot (x : 'a) : 'a * int =
+  (x, !work)

--- a/exercises/nondet_monad_defun/prepare.ml
+++ b/exercises/nondet_monad_defun/prepare.ml
@@ -1,0 +1,1 @@
+exception TODO

--- a/exercises/nondet_monad_defun/solution.log
+++ b/exercises/nondet_monad_defun/solution.log
@@ -1,0 +1,2 @@
+Learnocaml v.0.10 running.
+[ Loading the prelude. ][K[ Preparing the test environment. ][K[ Loading your code. ][K[ Loading the solution. ][K[ Preparing to launch the tests. ][K[ Launching the test bench. ][K.                              - Success - 8 points

--- a/exercises/nondet_monad_defun/solution.ml
+++ b/exercises/nondet_monad_defun/solution.ml
@@ -1,0 +1,118 @@
+(* The following four constructor functions are implemented already. *)
+
+let return (x : 'a) : 'a m =
+  MReturn x
+
+let (>>=) (m1 : 'a m) (m2 : 'a -> 'b m) : 'b m =
+  MBind (m1, m2)
+
+let fail : 'a m =
+  MFail
+
+let choose (m1 : 'a m) (m2 : 'a m) : 'a m =
+  MChoose (m1, m2)
+
+(* The bulk of the work is to implement an interpreter for each of the
+   data types [_ failure], [(_, _) success], and [_ m]. *)
+
+let rec apply_failure : type answer . answer failure -> unit -> answer =
+  fun f () ->
+    match f with
+    | FChoose (m2, s, f) ->
+        (* Invoked when the left branch of a choice has failed.
+           [m2] is the right branch of the choice.
+           [s] and [f] are the continuations of the choice. *)
+        compute m2 s f
+    | FSols ->
+        (* Used at the top level of [sols].
+           Invoked when there is no result. *)
+        Seq.Nil
+    | FSplit ->
+        (* Used at the top level of [msplit].
+           Invoked when there is no result. *)
+        None
+
+and apply_success : type a answer .
+  (a, answer) success -> a -> answer failure -> answer
+=
+  fun s x f ->
+    match s with
+    | SBind (m2, s) ->
+        (* Invoked when the left branch of a sequence produces a result [x].
+           [m2] is the right-hand side of the sequence.
+           [s] is the success continuation of the sequence. *)
+        compute (m2 x) s f
+    | SSols ->
+        (* Used at the top level of [sols].
+           Invoked when the computation produces a result [x]. *)
+        (* Hint: construct a sequence whose head is [x] and whose
+                 tail is [f], converted to the type of a sequence.
+                 There is an easy way of performing this conversion. *)
+        Seq.Cons (x, apply_failure f)
+    | SSplit ->
+        (* Used at the top level of [msplit].
+           Invoked when the computation produces a result [x]. *)
+        (* Hint: construct an optional-pair whose first component is [x]
+                 and whose second component is [f], converted to the type
+                 of a computation. There is an easy way of performing this
+                 conversion.  *)
+        Some (x, MReflect f)
+
+and compute : type a answer .
+  a m -> (a, answer) success -> answer failure -> answer
+=
+  fun m s f ->
+    match m with
+    | MDelay m ->
+        compute (m()) s f
+    | MReturn x ->
+        apply_success s x f
+    | MBind (m1, m2) ->
+        compute m1 (SBind (m2, s)) f
+    | MFail ->
+        apply_failure f ()
+    | MChoose (m1, m2) ->
+        compute m1 s (FChoose (m2, s, f))
+    | MReflect k ->
+        match apply_failure k () with
+        | None ->
+            apply_failure f ()
+            (* inlined version of [compute fail s f] *)
+        | Some (x, m) ->
+            apply_success s x (FChoose (m, s, f))
+            (* inlined version of [compute (choose (return x) m) s f] *)
+
+let sols (m : 'a m) : 'a Seq.t =
+  fun () ->
+    compute m SSols FSols
+
+let msplit (m : 'a m) : unit -> ('a * 'a m) option =
+  fun () ->
+    compute m SSplit FSplit
+
+let at_most_once (m : 'a m) : 'a m =
+  delay (fun () ->
+    match msplit m () with
+    | None ->
+        fail
+    | Some (x, _) ->
+        return x
+  )
+
+let rec interleave (m1 : 'a m) (m2 : 'a m) : 'a m =
+  delay (fun () ->
+    match msplit m1 () with
+    | None ->
+        m2
+    | Some (x1, m1) ->
+        choose (return x1) (interleave m2 m1)
+  )
+
+let rec (>>-) (m1 : 'a m) (m2 : 'a -> 'b m) : 'b m =
+  delay (fun () ->
+    match msplit m1 () with
+    | None ->
+        fail
+    | Some (x1, m1) ->
+        interleave (m2 x1) (m1 >>- m2)
+  )

--- a/exercises/nondet_monad_defun/solution.report.txt
+++ b/exercises/nondet_monad_defun/solution.report.txt
@@ -1,0 +1,46 @@
+Question 1
+  Found [return] with compatible type.
+  Found [>>=] with compatible type.
+  Found [fail] with compatible type.
+  Found [choose] with compatible type.
+  Found [sols] with compatible type.
+  Functional correctness
+    Success 1: The code seems correct. Tested 2411 scenarios.
+  Laziness
+    Success 1: The code seems lazy.
+Question 2
+  Found [return] with compatible type.
+  Found [>>=] with compatible type.
+  Found [fail] with compatible type.
+  Found [choose] with compatible type.
+  Found [sols] with compatible type.
+  Found [at_most_once] with compatible type.
+  Functional correctness
+    Success 1: The code seems correct. Tested 2486 scenarios.
+  Laziness
+    Success 1: The code seems lazy.
+Question 3
+  Found [return] with compatible type.
+  Found [>>=] with compatible type.
+  Found [fail] with compatible type.
+  Found [choose] with compatible type.
+  Found [sols] with compatible type.
+  Found [at_most_once] with compatible type.
+  Found [interleave] with compatible type.
+  Functional correctness
+    Success 1: The code seems correct. Tested 2867 scenarios.
+  Laziness
+    Success 1: The code seems lazy.
+Question 4
+  Found [return] with compatible type.
+  Found [>>=] with compatible type.
+  Found [fail] with compatible type.
+  Found [choose] with compatible type.
+  Found [sols] with compatible type.
+  Found [at_most_once] with compatible type.
+  Found [interleave] with compatible type.
+  Found [>>-] with compatible type.
+  Functional correctness
+    Success 1: The code seems correct. Tested 10356 scenarios.
+  Laziness
+    Success 1: The code seems lazy.

--- a/exercises/nondet_monad_defun/template.ml
+++ b/exercises/nondet_monad_defun/template.ml
@@ -1,0 +1,110 @@
+(* The following four constructor functions are implemented already. *)
+
+let return (x : 'a) : 'a m =
+  MReturn x
+
+let (>>=) (m1 : 'a m) (m2 : 'a -> 'b m) : 'b m =
+  MBind (m1, m2)
+
+let fail : 'a m =
+  MFail
+
+let choose (m1 : 'a m) (m2 : 'a m) : 'a m =
+  MChoose (m1, m2)
+
+(* The bulk of the work is to implement an interpreter for each of the
+   data types [_ failure], [(_, _) success], and [_ m]. *)
+
+let rec apply_failure : type answer . answer failure -> unit -> answer =
+  fun f () ->
+    match f with
+    | FChoose (m2, s, f) ->
+        (* Invoked when the left branch of a choice has failed.
+           [m2] is the right branch of the choice.
+           [s] and [f] are the continuations of the choice. *)
+        raise TODO (* one line *)
+    | FSols ->
+        (* Used at the top level of [sols].
+           Invoked when there is no result. *)
+        raise TODO (* one line *)
+    | FSplit ->
+        (* Used at the top level of [msplit].
+           Invoked when there is no result. *)
+        raise TODO (* one line *)
+
+and apply_success : type a answer .
+  (a, answer) success -> a -> answer failure -> answer
+=
+  fun s x f ->
+    match s with
+    | SBind (m2, s) ->
+        (* Invoked when the left branch of a sequence produces a result [x].
+           [m2] is the right-hand side of the sequence.
+           [s] is the success continuation of the sequence. *)
+        raise TODO (* one line *)
+    | SSols ->
+        (* Used at the top level of [sols].
+           Invoked when the computation produces a result [x]. *)
+        (* Hint: construct a sequence whose head is [x] and whose
+                 tail is [f], converted to the type of a sequence.
+                 There is an easy way of performing this conversion. *)
+        raise TODO (* one line *)
+    | SSplit ->
+        (* Used at the top level of [msplit].
+           Invoked when the computation produces a result [x]. *)
+        (* Hint: construct an optional-pair whose first component is [x]
+                 and whose second component is [f], converted to the type
+                 of a computation. There is an easy way of performing this
+                 conversion.  *)
+        raise TODO (* one line *)
+
+and compute : type a answer .
+  a m -> (a, answer) success -> answer failure -> answer
+=
+  fun m s f ->
+    match m with
+    | MDelay m ->
+        (* Hint: evaluate [m()] and continue. *)
+        raise TODO (* one line *)
+    | MReturn x ->
+        (* Hint: successfully produce the result [x]. *)
+        raise TODO (* one line *)
+    | MBind (m1, m2) ->
+        (* Hint: enter the left-hand side [m1] with an
+                 appropriate success continuation. *)
+        raise TODO (* one line *)
+    | MFail ->
+        (* Hint: fail. *)
+        raise TODO (* one line *)
+    | MChoose (m1, m2) ->
+        (* Hint: enter the left-hand side [m1] with an
+                 appropriate failure continuation. *)
+        raise TODO (* one line *)
+    | MReflect k ->
+        (* We have a failure continuation [k], which was captured earlier and
+           wrapped with [MReflect] so as to disguise it as a computation. We are
+           now asked to execute this computation. Thus, we must call this
+           failure continuation, whose answer type is [('a * 'a m) option].
+           Depending on whether this yields [None] or [Some (x, m)], we must
+           behave either like [fail] or like [choose (return x) m]. *)
+        raise TODO (* five lines *)
+
+let sols (m : 'a m) : 'a Seq.t =
+  (* TO DO: Define this function. *)
+  raise TODO (* one line *)
+
+let msplit (m : 'a m) : unit -> ('a * 'a m) option =
+  (* TO DO: Define this function. *)
+  raise TODO (* one line *)
+
+let at_most_once (m : 'a m) : 'a m =
+  (* TO DO: Define this function. *)
+  raise TODO
+
+let rec interleave (m1 : 'a m) (m2 : 'a m) : 'a m =
+  (* TO DO: Define this function. *)
+  raise TODO
+
+let rec (>>-) (m1 : 'a m) (m2 : 'a -> 'b m) : 'b m =
+  (* TO DO: Define this function. *)
+  raise TODO

--- a/exercises/nondet_monad_defun/test.ml
+++ b/exercises/nondet_monad_defun/test.ml
@@ -1,0 +1,1530 @@
+open Printf
+let iter = List.iter
+let map = List.map
+module T = Test_lib
+module R = Report
+type report = R.t
+(* Determinism. *)
+let () = Random.init 0
+
+(* The auto-grader. *)
+
+(* -------------------------------------------------------------------------- *)
+
+(* Some of the code below should move to separate library files. *)
+
+(* -------------------------------------------------------------------------- *)
+
+(* PPrintMini. *)
+
+(* -------------------------------------------------------------------------- *)
+
+(* A type of integers with infinity. *)
+
+type requirement =
+    int (* with infinity *)
+
+(* Infinity is encoded as [max_int]. *)
+
+let infinity : requirement =
+  max_int
+
+(* Addition of integers with infinity. *)
+
+let (++) (x : requirement) (y : requirement) : requirement =
+  if x = infinity || y = infinity then
+    infinity
+  else
+    x + y
+
+(* Comparison between an integer with infinity and a normal integer. *)
+
+let (<==) (x : requirement) (y : int) =
+  x <= y
+
+(* -------------------------------------------------------------------------- *)
+
+(* The type of documents. See [PPrintEngine] for documentation. *)
+
+type document =
+  | Empty
+  | FancyString of string * int * int * int
+  | Blank of int
+  | IfFlat of document * document
+  | HardLine
+  | Cat of requirement * document * document
+  | Nest of requirement * int * document
+  | Group of requirement * document
+
+(* -------------------------------------------------------------------------- *)
+
+(* Retrieving or computing the space requirement of a document. *)
+
+let rec requirement = function
+  | Empty ->
+      0
+  | FancyString (_, _, _, len)
+  | Blank len ->
+      len
+  | IfFlat (doc1, _) ->
+      requirement doc1
+  | HardLine ->
+      infinity
+  | Cat (req, _, _)
+  | Nest (req, _, _)
+  | Group (req, _) ->
+      req
+
+(* -------------------------------------------------------------------------- *)
+
+(* Document constructors. *)
+
+let empty =
+  Empty
+
+let fancysubstring s ofs len apparent_length =
+  if len = 0 then
+    empty
+  else
+    FancyString (s, ofs, len, apparent_length)
+
+let fancystring s apparent_length =
+  fancysubstring s 0 (String.length s) apparent_length
+
+let utf8_length s =
+  let rec length_aux s c i =
+    if i >= String.length s then c else
+    let n = Char.code (String.unsafe_get s i) in
+    let k =
+      if n < 0x80 then 1 else
+      if n < 0xe0 then 2 else
+      if n < 0xf0 then 3 else 4
+    in
+    length_aux s (c + 1) (i + k)
+  in
+  length_aux s 0 0
+
+let utf8string s =
+  fancystring s (utf8_length s)
+
+let utf8format f =
+  ksprintf utf8string f
+
+let char c =
+  assert (c <> '\n');
+  fancystring (String.make 1 c) 1
+
+let space =
+  char ' '
+
+let semicolon =
+  char ';'
+
+let hardline =
+  HardLine
+
+let blank n =
+  match n with
+  | 0 ->
+      empty
+  | 1 ->
+      space
+  | _ ->
+      Blank n
+
+let ifflat doc1 doc2 =
+  match doc1 with
+  | IfFlat (doc1, _)
+  | doc1 ->
+      IfFlat (doc1, doc2)
+
+let internal_break i =
+  ifflat (blank i) hardline
+
+let break0 =
+  internal_break 0
+
+let break1 =
+  internal_break 1
+
+let break i =
+  match i with
+  | 0 ->
+      break0
+  | 1 ->
+      break1
+  | _ ->
+      internal_break i
+
+let (^^) x y =
+  match x, y with
+  | Empty, _ ->
+      y
+  | _, Empty ->
+      x
+  | _, _ ->
+      Cat (requirement x ++ requirement y, x, y)
+
+let nest i x =
+  assert (i >= 0);
+  Nest (requirement x, i, x)
+
+let group x =
+  let req = requirement x in
+  if req = infinity then
+    x
+  else
+    Group (req, x)
+
+(* -------------------------------------------------------------------------- *)
+
+(* Printing blank space (indentation characters). *)
+
+let blank_length =
+  80
+
+let blank_buffer =
+  String.make blank_length ' '
+
+let rec blanks output n =
+  if n <= 0 then
+    ()
+  else if n <= blank_length then
+    Buffer.add_substring output blank_buffer 0 n
+  else begin
+    Buffer.add_substring output blank_buffer 0 blank_length;
+    blanks output (n - blank_length)
+  end
+
+(* -------------------------------------------------------------------------- *)
+
+(* The rendering engine maintains the following internal state. *)
+
+(* For simplicity, the ribbon width is considered equal to the line
+   width; in other words, there is no ribbon width constraint. *)
+
+(* For simplicity, the output channel is required to be an OCaml buffer.
+   It is stored within the [state] record. *)
+
+type state =
+  {
+    (* The line width. *)
+    width: int;
+    (* The current column. *)
+    mutable column: int;
+    (* The output buffer. *)
+    mutable output: Buffer.t;
+  }
+
+(* -------------------------------------------------------------------------- *)
+
+(* For simplicity, the rendering engine is *not* in tail-recursive style. *)
+
+let rec pretty state (indent : int) (flatten : bool) doc =
+  match doc with
+
+  | Empty ->
+      ()
+
+  | FancyString (s, ofs, len, apparent_length) ->
+      Buffer.add_substring state.output s ofs len;
+      state.column <- state.column + apparent_length
+
+  | Blank n ->
+      blanks state.output n;
+      state.column <- state.column + n
+
+  | HardLine ->
+      assert (not flatten);
+      Buffer.add_char state.output '\n';
+      blanks state.output indent;
+      state.column <- indent
+
+  | IfFlat (doc1, doc2) ->
+      pretty state indent flatten (if flatten then doc1 else doc2)
+
+  | Cat (_, doc1, doc2) ->
+      pretty state indent flatten doc1;
+      pretty state indent flatten doc2
+
+  | Nest (_, j, doc) ->
+      pretty state (indent + j) flatten doc
+
+  | Group (req, doc) ->
+      let flatten = flatten || state.column ++ req <== state.width in
+      pretty state indent flatten doc
+
+(* -------------------------------------------------------------------------- *)
+
+(* The engine's entry point. *)
+
+let pretty width doc =
+  let output = Buffer.create 512 in
+  let state = { width; column = 0; output } in
+  pretty state 0 false doc;
+  Buffer.contents output
+
+(* -------------------------------------------------------------------------- *)
+
+(* Additions to PPrintMini. *)
+
+let separate (sep : 'a) (xs : 'a list) : 'a list =
+  match xs with
+  | [] ->
+      []
+  | x :: xs ->
+      x :: List.flatten (List.map (fun x -> [sep; x]) xs)
+
+let concat (docs : document list) : document =
+  List.fold_right (^^) docs empty
+
+let comma =
+  utf8string "," ^^ break 1
+
+let commas docs =
+  concat (separate comma docs)
+
+let semi =
+  utf8string ";" ^^ break 1
+
+let semis docs =
+  concat (separate semi docs)
+
+let int i =
+  utf8format "%d" i
+
+let block doc =
+  nest 2 (break 0 ^^ doc) ^^ break 0
+
+let parens doc =
+  utf8string "(" ^^ block doc ^^ utf8string ")"
+
+let brackets doc =
+  utf8string "[" ^^ block doc ^^ utf8string "]"
+
+let ocaml_array_brackets doc =
+  utf8string "[| " ^^ block doc ^^ utf8string "|]"
+
+let tuple docs =
+  group (parens (commas docs))
+
+let list docs =
+  group (brackets (semis docs))
+
+let construct label docs =
+  match docs with
+  | [] ->
+      utf8string label
+  | _ ->
+      utf8string label ^^ space ^^ tuple docs
+
+let flow docs =
+  match docs with
+  | [] ->
+      []
+  | doc :: docs ->
+      doc :: map (fun doc -> group (break 1) ^^ doc) docs
+
+let raw_apply docs =
+  group (concat (flow docs))
+
+let apply f docs =
+  raw_apply (utf8string f :: docs)
+
+let parens_apply f docs =
+  parens (apply f docs)
+
+let piped_apply f docs =
+  (* Isolate the last argument. *)
+  assert (List.length docs > 0);
+  let docs = List.rev docs in
+  let doc, docs = List.hd docs, List.rev (List.tl docs) in
+  (* Print. *)
+  group (doc ^^ break 1 ^^ utf8string "|>" ^^ space ^^ apply f docs)
+
+let wrap (print : 'a -> document) : 'a -> string =
+  fun x -> pretty 70 (group (print x))
+
+(* -------------------------------------------------------------------------- *)
+
+(* An implementation of symbolic sequences. *)
+
+module SymSeq = struct
+
+  type _ seq =
+  | Empty    : 'a seq
+  | Singleton: 'a -> 'a seq
+  | Sum      : int * 'a seq * 'a seq -> 'a seq
+  | Product  : int * 'a seq * 'b seq -> ('a * 'b) seq
+  | Map      : int * ('a -> 'b) * 'a seq -> 'b seq
+
+  exception OutOfBounds
+
+  let length (type a) (s : a seq) : int =
+    match s with
+    | Empty ->
+        0
+    | Singleton _ ->
+        1
+    | Sum (length, _, _) ->
+        length
+    | Product (length, _, _) ->
+        length
+    | Map (length, _, _) ->
+        length
+
+  let is_empty s =
+    length s = 0
+
+  let empty =
+    Empty
+
+  let singleton x =
+    Singleton x
+
+  let sum s1 s2 =
+    if is_empty s1 then s2
+    else if is_empty s2 then s1
+    else Sum (length s1 + length s2, s1, s2)
+
+  let bigsum ss =
+    List.fold_left sum empty ss
+
+  let product s1 s2 =
+    if is_empty s1 || is_empty s2 then
+      empty
+    else
+      Product (length s1 * length s2, s1, s2)
+
+  let map phi s =
+    if is_empty s then
+      empty
+    else
+      Map (length s, phi, s)
+
+  let rec get : type a . a seq -> int -> a =
+    fun s i ->
+      match s with
+      | Empty ->
+          raise OutOfBounds
+      | Singleton x ->
+          if i = 0 then x else raise OutOfBounds
+      | Sum (_, s1, s2) ->
+          let n1 = length s1 in
+          if i < n1 then get s1 i
+          else get s2 (i - n1)
+      | Product (_, s1, s2) ->
+          let q, r = i / length s2, i mod length s2 in
+          get s1 q, get s2 r
+      | Map (_, phi, s) ->
+          phi (get s i)
+
+  let rec foreach : type a . a seq -> (a -> unit) -> unit =
+    fun s k ->
+      match s with
+      | Empty ->
+          ()
+      | Singleton x ->
+          k x
+      | Sum (_, s1, s2) ->
+          foreach s1 k;
+          foreach s2 k
+      | Product (_, s1, s2) ->
+          foreach s1 (fun x1 ->
+            foreach s2 (fun x2 ->
+              k (x1, x2)
+            )
+          )
+      | Map (_, phi, s) ->
+          foreach s (fun x -> k (phi x))
+
+  let elements (s : 'a seq) : 'a list =
+    let xs = ref [] in
+    foreach s (fun x -> xs := x :: !xs);
+    List.rev !xs
+
+  (* Extract a list of at most [threshold] elements from the sequence [s]. *)
+
+  let sample threshold (s : 'a seq) : 'a list =
+    if length s <= threshold then
+      (* If the sequence is short enough, keep of all its elements. *)
+      elements s
+    else
+      (* Otherwise, keep a randomly chosen sample. *)
+      let xs = ref [] in
+      for i = 1 to threshold do
+        let i = Random.int (length s) in
+        let x = get s i in
+        xs := x :: !xs
+      done;
+      !xs
+
+end
+
+type 'a seq =
+  'a SymSeq.seq
+
+(* -------------------------------------------------------------------------- *)
+
+(* A fixed point combinator. *)
+
+let fix : type a b . ((a -> b) -> (a -> b)) -> (a -> b) =
+  fun ff ->
+    let table = Hashtbl.create 128 in
+    let rec f (x : a) : b =
+      try
+        Hashtbl.find table x
+      with Not_found ->
+        let y = ff f x in
+        Hashtbl.add table x y;
+        y
+    in
+    f
+
+let   curry f x y = f (x, y)
+let uncurry f (x, y) = f x y
+
+let fix2 : type a b c . ((a -> b -> c) -> (a -> b -> c)) -> (a -> b -> c) =
+  fun ff ->
+    let ff f = uncurry (ff (curry f)) in
+    curry (fix ff)
+
+(* -------------------------------------------------------------------------- *)
+
+(* MiniFeat. *)
+
+module Feat = struct
+
+  (* Core combinators. *)
+
+  type 'a enum =
+    int -> 'a SymSeq.seq
+
+  let empty : 'a enum =
+    fun _s ->
+      SymSeq.empty
+
+  let zero =
+    empty
+
+  let enum (xs : 'a SymSeq.seq) : 'a enum =
+    fun s ->
+      if s = 0 then xs else SymSeq.empty
+
+  let just (x : 'a) : 'a enum =
+    (* enum (SymSeq.singleton x) *)
+    fun s ->
+      if s = 0 then SymSeq.singleton x else SymSeq.empty
+
+  let pay (enum : 'a enum) : 'a enum =
+    fun s ->
+      if s = 0 then SymSeq.empty else enum (s-1)
+
+  let sum (enum1 : 'a enum) (enum2 : 'a enum) : 'a enum =
+    fun s ->
+      SymSeq.sum (enum1 s) (enum2 s)
+
+  let ( ++ ) =
+    sum
+
+  let rec _up i j =
+    if i <= j then
+      i :: _up (i + 1) j
+    else
+      []
+
+  let product (enum1 : 'a enum) (enum2 : 'b enum) : ('a * 'b) enum =
+    fun s ->
+      SymSeq.bigsum (
+        List.map (fun s1 ->
+          let s2 = s - s1 in
+          SymSeq.product (enum1 s1) (enum2 s2)
+        ) (_up 0 s)
+      )
+
+  let ( ** ) =
+    product
+
+  let balanced_product (enum1 : 'a enum) (enum2 : 'b enum) : ('a * 'b) enum =
+    fun s ->
+      if s mod 2 = 0 then
+        let s = s / 2 in
+        SymSeq.product (enum1 s) (enum2 s)
+      else
+        let s = s / 2 in
+        SymSeq.sum
+          (SymSeq.product (enum1 s) (enum2 (s+1)))
+          (SymSeq.product (enum1 (s+1)) (enum2 s))
+
+  let ( *-* ) =
+    balanced_product
+
+  let map (phi : 'a -> 'b) (enum : 'a enum) : 'b enum =
+    fun s ->
+      SymSeq.map phi (enum s)
+
+  (* Convenience functions. *)
+
+  let finite (xs : 'a list) : 'a enum =
+    List.fold_left (++) zero (List.map just xs)
+
+  let bool : bool enum =
+    just false ++ just true
+
+  let list (elem : 'a enum) : 'a list enum =
+    let cons (x, xs) = x :: xs in
+    fix (fun list ->
+      just [] ++ pay (map cons (elem ** list))
+    )
+
+  (* Extract a list of at most [threshold] elements of each size,
+     for every size up to [s] (included), from the enumeration [e]. *)
+
+  let sample threshold s (e : 'a enum) : 'a list =
+    List.flatten (
+      List.map (fun i ->
+        SymSeq.sample threshold (e i)
+      ) (_up 0 s)
+    )
+
+end
+
+type 'a enum =
+  'a Feat.enum
+
+(* -------------------------------------------------------------------------- *)
+
+(* Generic testing utilities. *)
+
+(* When we fail, the exception carries a learn-ocaml report. *)
+
+exception Fail of report
+
+(* [section title report] encloses the report [report] within a section
+   entitled [title], producing a larger report. *)
+
+let section title report : report =
+  [R.Section ([R.Text title], report)]
+
+(* This generic function takes as an argument the text of the message that
+   will be displayed. A message is a list of inline things. *)
+
+let fail (text : R.inline list) =
+  let report = [R.Message (text, R.Failure)] in
+  raise (Fail report)
+
+(* This is a special case where the message is a singleton list containing
+   a single string. The string can be formatted using a printf format. *)
+
+let fail_text format =
+  Printf.ksprintf (fun s -> fail [R.Text s]) format
+
+(* [protect f] evaluates [f()], which either returns normally and produces a
+   report, or raises [Fail] and produces a report. In either case, the report
+   is returned. *)
+
+(* If an unexpected exception is raised, in student code or in grading code,
+   the exception is displayed as part of a failure report. (Ideally, grading
+   code should never raise an exception!) It is debatable whether one should
+   show just the name of the exception, or a full backtrace; I choose the
+   latter, on the basis that more information is always preferable. *)
+
+let protect f =
+  try
+    T.run_timeout f
+  with
+  | Fail report ->
+      report
+  | TODO ->
+      let text = [
+        R.Text "Not yet implemented."
+      ] in
+      let report = [R.Message (text, R.Failure)] in
+      report
+  | (e : exn) ->
+      let text = [
+        R.Text "The following exception is raised and never caught:";
+        R.Break;
+        R.Output (Printexc.to_string e);
+        R.Output (Printexc.get_backtrace());
+      ] in
+      let report = [R.Message (text, R.Failure)] in
+      report
+
+(* [successful] tests whether a report is successful. *)
+
+let successful_status = function
+  | R.Success _
+  | R.Warning
+  | R.Informative
+  | R.Important ->
+     true
+  | R.Failure ->
+     false
+
+let rec successful_item = function
+  | R.Section (_, r) ->
+      successful r
+  | R.Message (_, status) ->
+      successful_status status
+
+and successful (r : report) =
+  List.for_all successful_item r
+
+let (-@>) (r : report) (f : unit -> report) : report =
+  if successful r then
+    r @ f()
+  else
+    r
+
+(* -------------------------------------------------------------------------- *)
+
+(* Generic test functions. *)
+
+let grab ty name k =
+  T.test_value (T.lookup_student ty name) k
+
+let test_value_0 name ty reference eq =
+  grab ty name (fun candidate ->
+    protect (fun () ->
+      if not (eq candidate reference) then
+        fail [
+          R.Code name; R.Text "is incorrect.";
+        ];
+      let message = [ R.Code name; R.Text "is correct."; ] in
+      [ R.Message (message, R.Success 1) ]
+    )
+  )
+
+let correct name =
+  let message = [ R.Code name; R.Text "seems correct."; ] in
+  [ R.Message (message, R.Success 1) ]
+
+(* When doing black-box testing of a complete module, we are not testing just
+   one function in isolation, but a group of functions together. In that case,
+   the wording of the error message is somewhat different. Instead of saying
+   that a specific function is incorrect, we want to say that an expression
+   [expr] yields an incorrect result. *)
+
+let eq_behavior eq_value actual_behavior expected_behavior =
+  match actual_behavior, expected_behavior with
+  | Ok actual, Ok expected ->
+      eq_value actual expected (* value comparison *)
+  | Error actual, Error expected ->
+      actual = expected  (* exception comparison *)
+  | Ok _, Error _
+  | Error _, Ok _ ->
+      false
+
+let show_actual_behavior show_value behavior =
+  match behavior with
+  | Ok v ->
+      R.Text "produces the following result:" ::
+      R.Output (show_value v) ::
+      []
+  | Error e ->
+      R.Text "raises the following exception:" ::
+      R.Output (Printexc.to_string e) ::
+      []
+
+let show_expected_behavior show_value behavior =
+  match behavior with
+  | Ok v ->
+      R.Text "This is invalid. Producing the following result is valid:" ::
+      R.Output (show_value v) ::
+      []
+  | Error e ->
+      R.Text "This is invalid. Raising the following exception is valid:" ::
+      R.Output (Printexc.to_string e) ::
+      []
+
+let something_is_wrong =
+  R.Text "Something is wrong." ::
+  []
+
+let incorrect name =
+  R.Code name :: R.Text "is incorrect." ::
+  R.Break ::
+  []
+
+let black_box_compare
+  (* Value equality and display, used to compare and show results. *)
+  eq_value show_value
+  (* The beginning of the error message. Use [something_is_wrong] or [incorrect name]. *)
+  announcement
+  (* Expression display. *)
+  show_expr expr
+  (* Actual behavior and expected behavior. *)
+  actual_behavior
+  expected_behavior
+=
+  (* Allow [TODO] to escape and abort the whole test. *)
+  if actual_behavior = Error TODO then
+    raise TODO
+  else if not (eq_behavior eq_value actual_behavior expected_behavior) then
+    fail (
+      announcement @
+      R.Text "The following expression:" ::
+      R.Break ::
+      R.Code (show_expr expr) ::
+      R.Break ::
+      show_actual_behavior show_value actual_behavior @
+      show_expected_behavior show_value expected_behavior
+    )
+
+let test_value_1 name ty reference printx showy eqy tests =
+  grab ty name (fun candidate ->
+    protect (fun () ->
+      tests |> List.iter (fun x ->
+        let actual_behavior = T.result (fun () -> candidate x)
+        and expected_behavior = T.result (fun () -> reference x) in
+        let print_expr () =
+          apply name [ printx x ]
+            (* beware: [printx] must produce parentheses if necessary *)
+        in
+        black_box_compare
+          eqy showy
+          (incorrect name)
+          (wrap print_expr) ()
+          actual_behavior
+          expected_behavior
+      );
+      correct name
+    )
+  )
+
+let test_value_2 name ty reference printx1 printx2 showy eqy tests =
+  grab ty name (fun candidate ->
+    protect (fun () ->
+      tests |> List.iter (fun ((x1, x2) as x) ->
+        let actual_behavior = T.result (fun () -> candidate x1 x2)
+        and expected_behavior = T.result (fun () -> reference x1 x2) in
+        let print_expr () =
+          apply name [ printx1 x1; printx2 x2 ]
+            (* beware: [printx1] and [printx2] must produce parentheses
+               if necessary *)
+        in
+        black_box_compare
+          eqy showy
+          (incorrect name)
+          (wrap print_expr) ()
+          actual_behavior
+          expected_behavior
+      );
+      correct name
+    )
+  )
+
+let test_value_3 name ty reference printx1 printx2 printx3 showy eqy tests =
+  grab ty name (fun candidate ->
+    protect (fun () ->
+      tests |> List.iter (fun ((x1, x2, x3) as x) ->
+        let actual_behavior = T.result (fun () -> candidate x1 x2 x3)
+        and expected_behavior = T.result (fun () -> reference x1 x2 x3) in
+        let print_expr () =
+          apply name [ printx1 x1; printx2 x2; printx3 x3 ]
+            (* beware: [printx1], etc. must produce parentheses
+               if necessary *)
+        in
+        black_box_compare
+          eqy showy
+          (incorrect name)
+          (wrap print_expr) ()
+          actual_behavior
+          expected_behavior
+      );
+      correct name
+    )
+  )
+
+(* -------------------------------------------------------------------------- *)
+
+(* List-based enumerations. *)
+
+let flat_map f xss =
+  List.flatten (List.map f xss)
+
+(* [up i j] is the list of the integers of [i] included up to [j] excluded. *)
+
+(* [upk i j k] is [up i j @ k]. *)
+
+let rec upk i j k =
+  if i < j then
+    i :: upk (i + 1) j k
+  else
+    k
+
+let up i j =
+  upk i j []
+
+(* [pairs xs ys] is the list of all pairs [x, y] where [x] is drawn from [xs]
+   and [y] is drawn from [ys]. In other words, it is the Cartesian product of
+   the lists [xs] and [ys]. *)
+
+let pairs xs ys =
+  xs |> flat_map (fun x ->
+    ys |> flat_map (fun y ->
+      [x, y]
+    )
+  )
+
+(* [split n f] enumerates all manners of splitting [n] into [n1 + n2], where
+   [n1] and [n2] can be zero. For each such split, the enumeration [f n1 n2]
+   is produced. *)
+
+let split n f =
+  flat_map (fun n1 ->
+    let n2 = n - n1 in
+    f n1 n2
+  ) (up 0 (n+1))
+
+(* If [f i] is an enumeration, then [deepening f n] is the concatenation
+   of the enumerations [f 0, f 1, ... f n]. *)
+
+let deepening (f : int -> 'a list) (n : int) : 'a list =
+  flat_map f (up 0 (n+1))
+
+(* -------------------------------------------------------------------------- *)
+
+(* Printers. *)
+
+(* A printer for strings. *)
+
+let show_string s =
+  sprintf "\"%s\"" (String.escaped s)
+
+let print_string s =
+  utf8string (show_string s)
+
+(* A printer for integers. *)
+
+let print_int =
+  int
+
+let show_int i =
+  sprintf "%d" i
+
+(* A printer for characters. *)
+
+let show_char c =
+  sprintf "'%s'" (Char.escaped c)
+
+(* A printer for Booleans. *)
+
+let show_bool b =
+  if b then "true" else "false"
+
+let print_bool b =
+  utf8string (show_bool b)
+
+(* A printer for options. *)
+
+let print_option print = function
+  | None ->
+       utf8string "None"
+  | Some x ->
+       construct "Some" [ print x ]
+
+(* A printer for arrays. *)
+
+let print_array print_element a =
+  group (ocaml_array_brackets (concat (
+    a |> Array.map (fun x ->
+      print_element x ^^ semicolon ^^ break 1
+    ) |> Array.to_list
+  )))
+
+(* A printer for lists. *)
+
+let print_list print_element xs =
+  list (map print_element xs)
+
+let print_list_int =
+  print_list print_int
+
+let show_list_int =
+  wrap print_list_int
+
+let print_int_int (x, t) =
+  parens (
+    utf8format "(* value: *) %d, (* work: *) %d" x t
+  )
+
+let print_list_int_int =
+  print_list print_int_int
+
+let show_list_int_int =
+  wrap print_list_int_int
+
+(* -------------------------------------------------------------------------- *)
+
+(* A DSL for monadic computations. *)
+
+(* The syntax of pure expressions allows zero-ary operators (constants) of
+   type [int] and unary operators of type ['a -> bool] and binary operators of
+   type ['a -> 'a -> 'a]. Each operator is accompanied with its textual
+   appearance as a plain OCaml expression. *)
+
+(* In the type [('g, 'a) expr], ['g] is the type of every variable in scope,
+   and ['a] is the type of the expression. *)
+
+(* In the syntax of computations, we restrict the type of [CBind] so that
+   every intermediate computation has result type ['a] and (therefore) every
+   variable in scope has type ['a] as well. This removes the need for dealing
+   with heterogeneous environments (both at the type level and value level),
+   facilitates printing of computations, etc. *)
+
+(* We ask the student to implement [at_most_once] rather than [once] because
+   the former has a simpler type, which fits the restriction above. *)
+
+type (_, _) expr =
+  | EVar: int (* de Bruijn index *) -> ('g, 'g) expr
+  | EConst: int -> ('g, int) expr
+
+type fair =
+  bool
+    (* The fair variant of [choose] is [interleave]. *)
+    (* The fair variant of [>>=] is [>>-]. *)
+
+type 'a comp =
+  (* Combinators implemented by me. *)
+  | CDelay of 'a comp
+  | CTick of 'a comp
+  (* Core combinators. (Unfair variants.) (Question 1.) *)
+  | CRet of ('a, 'a) expr
+  | CBind of fair * 'a comp * 'a comp (* >>= *)
+  | CFail
+  | CChoose of fair * 'a comp * 'a comp
+  (* More combinators. (Fair variants.) (Questions 2-4.) *)
+  | CAtMostOnce of 'a comp
+
+(* Generators. *)
+
+module DSLGen = struct
+
+  open Feat
+
+  (* Integer expressions. *)
+
+  (* [n] is the number of variables in scope. Memoization takes place over the
+     pair [(n, s)], where [s] is the size parameter, which remains implicit. *)
+
+  let evar x = EVar x
+  let econst k = EConst k
+
+  let int_expr : int -> (int, int) expr enum =
+    fix2 (fun int_expr n ->
+      map evar (finite (up 0 n)) ++
+      map econst (finite [ 0; 1 ])
+    )
+
+  (* Commands. *)
+
+  let cret e = CRet e
+  let cbind (c1, c2) = CBind (false, c1, c2)
+  let cdelay c = CDelay c
+  let ctick c = CTick c
+  let cchoose (c1, c2) = CChoose (false, c1, c2)
+  let catmostonce c = CAtMostOnce c
+  let cfairbind (c1, c2) = CBind (true, c1, c2)
+  let cfairchoose (c1, c2) = CChoose (true, c1, c2)
+
+  let core comp n =
+    map cret (int_expr n) ++
+    just CFail ++
+    pay (
+      map cbind (comp n ** comp (n+1)) ++
+      map cdelay (comp n) ++
+      map cchoose (comp n ** comp n)
+    )
+
+  (* Depending on the question number (Question 1, 2, etc.) we use more
+     and more combinators. *)
+
+  let q1 : int -> int comp enum =
+    fix2 (fun comp n ->
+      core comp n
+    )
+
+  let q2 : int -> int comp enum =
+    fix2 (fun comp n ->
+      core comp n ++
+      pay (map catmostonce (comp n))
+    )
+
+  let q3 : int -> int comp enum =
+    fix2 (fun comp n ->
+      core comp n ++
+      pay (map catmostonce (comp n)) ++
+      pay (map cfairchoose (comp n ** comp n))
+    )
+
+  let q4 : int -> int comp enum =
+    fix2 (fun comp n ->
+      core comp n ++
+      pay (map catmostonce (comp n)) ++
+      pay (map cfairchoose (comp n ** comp n)) ++
+      pay (map cfairbind (comp n ** comp n))
+    )
+
+end
+
+(* Instrumenting a command with [tick] instructions. *)
+
+(* We could insert [tick]s everywhere, but our counter-examples are a
+   little more readable if we insert fewer ticks. *)
+
+let rec instrument c =
+  match c with
+  | CRet _
+  | CFail ->
+      (* Tick [return] and [fail]. *)
+      CTick c
+  | CBind (fair, c1, c2) ->
+      (* Do not tick [bind]. *)
+      CBind (fair, instrument c1, instrument c2)
+  | CDelay c ->
+      (* Do not tick [delay]. *)
+      CDelay (instrument c)
+  | CTick c ->
+      (* won't happen *)
+      assert false
+  | CChoose (fair, c1, c2) ->
+      (* Do not tick [choose]. *)
+      CChoose (fair, instrument c1, instrument c2)
+  | CAtMostOnce c ->
+      (* Do not tick [at_most_once]. *)
+      CAtMostOnce (instrument c)
+
+(* Printers. *)
+
+module DSLPrinter = struct
+
+  type senv =
+    int
+
+  let show_var senv x =
+    assert (0 <= x && x < senv);
+    (* Convert the de Bruijn index [x] to a de Bruijn level. *)
+    let x = senv - 1 - x in
+    (* Use a fixed conversion scheme. *)
+    assert (x < 26);
+    let c = Char.chr (Char.code 'a' + x) in
+    String.make 1 c
+
+  let print_var senv x =
+    utf8string (show_var senv x)
+
+  let rec print_atomic_expr : type g a . senv -> (g, a) expr -> document =
+    fun senv e ->
+      match e with
+      | EVar x ->
+          print_var senv x
+      | EConst k ->
+          print_int k
+      | _ ->
+          parens (print_expr senv e)
+
+  and print_expr : type g a . senv -> (g, a) expr -> document =
+    fun senv e ->
+      match e with
+      | EVar _ ->
+          print_atomic_expr senv e
+      | EConst _ ->
+          print_atomic_expr senv e
+
+  let rec print_atomic_comp senv c =
+    match c with
+    | CFail ->
+        utf8string "fail"
+    | _ ->
+        parens (print_comp senv c)
+
+  and print_tight_comp senv c =
+    match c with
+    | CFail ->
+        print_atomic_comp senv c
+    | CRet e ->
+        apply "return" [ print_atomic_expr senv e ]
+    | CDelay c ->
+        apply "delay" [ print_atomic_comp senv c ]
+    | CTick c ->
+        apply "tick" [ print_atomic_comp senv c ]
+    | CAtMostOnce c ->
+        apply "at_most_once" [ print_atomic_comp senv c ]
+    | CChoose (fair, c1, c2) ->
+        apply
+          (if fair then "interleave" else "choose")
+          [ print_atomic_comp senv c1; print_atomic_comp senv c2 ]
+    | _ ->
+        parens (print_comp senv c)
+
+  and print_comp senv c =
+    group begin match c with
+    | CBind (fair, c1, c2) ->
+        let op = if fair then ">>-" else ">>=" in
+        group (
+          print_tight_comp senv c1 ^^ break 1 ^^
+          utf8format "%s fun %s ->" op (show_var (senv+1) 0)
+        ) ^^ break 1 ^^
+        print_tight_comp (senv+1) c2
+    | _ ->
+        print_tight_comp senv c
+    end
+
+  let print_atomic_comp c =
+    print_atomic_comp 0 c
+
+  let to_list doc =
+    piped_apply "Seq.to_list" [ doc ]
+
+  let take depth doc =
+    piped_apply "Seq.take" [ print_int depth; doc ]
+
+  let sols doc =
+    apply "sols" [ doc ]
+
+  let snapshot doc =
+    apply "Seq.map" [ utf8string "snapshot"; doc ]
+
+  let print_comp_sols_take depth c =
+    to_list (take depth (sols (print_atomic_comp c)))
+
+  let show_comp_sols_take depth =
+    wrap (print_comp_sols_take depth)
+
+  let print_comp_sols_snapshot_take depth c =
+    to_list (take depth (snapshot (sols (print_atomic_comp c))))
+
+  let show_comp_sols_snapshot_take depth =
+    wrap (print_comp_sols_snapshot_take depth)
+
+end
+
+(* A DSL interpreter. *)
+
+(* An expression evaluator. *)
+
+(* This evaluator is parameterized over an implementation of the signature
+   [REQUIRED]. *)
+
+(* Because (I think) we can only grab the student's code at a monomorphic
+   type, we cannot require these functions to be polymorphic. We require
+   just the monomorphic instances that we need for our test. *)
+
+type mono =
+  int
+
+module type REQUIRED = sig
+  val return: mono -> mono m
+  val (>>=) : mono m -> (mono -> mono m) -> mono m
+  val fail: mono m
+  val choose: mono m -> mono m -> mono m
+  (* The following components are optional, as they appear in
+     Questions 2-4. *)
+  val at_most_once: (mono m -> mono m) option
+  val interleave: (mono m -> mono m -> mono m) option
+  val (>>-): (mono m -> (mono -> mono m) -> mono m) option
+end
+
+module S = struct
+  include Solution
+  let at_most_once = Some at_most_once
+  let interleave = Some interleave
+  let (>>-) = Some (>>-)
+end
+
+let solution =
+  (module S : REQUIRED)
+
+let project o =
+  match o with
+  | Some x -> x
+  | None   -> assert false
+
+module DSLInterpreter = struct
+
+  let rec eval_expr : type g a . g list -> (g, a) expr -> a =
+    fun env e ->
+      match e with
+      | EVar x ->
+          List.nth env x
+      | EConst k ->
+          k
+
+  let eval_comp required (env : mono list) (c : mono comp) : mono m =
+    let module R = (val required : REQUIRED) in
+    let open R in
+    let rec eval_comp env c =
+      match c with
+      | CRet e ->
+          return (eval_expr env e)
+      | CBind (fair, c1, c2) ->
+          let bind = if fair then project (>>-) else (>>=) in
+          bind
+            (eval_comp env c1)
+            (fun x1 -> eval_comp (x1 :: env) c2)
+      | CDelay c ->
+          delay (fun () -> eval_comp env c)
+      | CTick c ->
+          tick (eval_comp env c)
+      | CFail ->
+          fail
+      | CChoose (fair, c1, c2) ->
+          let plus = if fair then project interleave else choose in
+          plus (eval_comp env c1) (eval_comp env c2)
+      | CAtMostOnce c ->
+          let at_most_once = project at_most_once in
+          at_most_once (eval_comp env c)
+    in
+    eval_comp env c
+
+  let eval_comp required (c : mono comp) : mono m =
+    eval_comp required [] c
+
+end
+
+(* -------------------------------------------------------------------------- *)
+
+(* Our black-box grading machinery. *)
+
+(* In Question 1, we grade four construction functions: [return], [>>=],
+   [fail], [choose], observed through one observation function, [sols].
+   In Questions 2-4, we gradually add three more construction functions,
+   [at_most_once], [interleave], and [>>-]. The testing machinery is the
+   same. *)
+
+module P = DSLPrinter
+module I = DSLInterpreter
+
+(* In order to avoid trouble with infinite sequences, we compare and print
+   sequences only down to a certain [depth]. *)
+
+let depth =
+  20
+
+(* First, we test functional correctness. We generate a computation using the
+   constructor functions, and apply [sols] to it, yielding a sequence. We
+   truncate this sequence at depth [depth] and force its evaluation by turning
+   it into a list. Then, we check that this list of results is correct by
+   comparing against our solution. *)
+
+let test_correctness tests student sols =
+  tests |> List.iter (fun (c : mono comp) ->
+    let expected_behavior =
+      Ok (
+        I.eval_comp solution c
+        |> Solution.sols
+        |> Seq.take depth
+        |> Seq.to_list
+      )
+    in
+    let actual_behavior =
+      T.result (fun () ->
+        I.eval_comp student c
+        |> sols
+        |> Seq.take depth
+        |> Seq.to_list
+      )
+    in
+    black_box_compare
+      (=) show_list_int
+      something_is_wrong
+      (P.show_comp_sols_take depth) c
+      actual_behavior
+      expected_behavior
+  );
+  (* Success. *)
+  let points = 1 in
+  let msg =
+    sprintf "The code seems correct. Tested %d scenarios."
+      (List.length tests)
+  in
+  [ R.success points msg ]
+
+(* Second, we test that computations are performed on demand, that is, as late
+   as possible. That is, demanding the next result should force execution to
+   take place only as far as necessary in order to produce this result. To
+   check this, we instrument our test computations with [tick] instructions,
+   which increment the global counter [time], and decorate every result with
+   the time at which it is produced. (A call to [Seq.map snapshot] suffices
+   for this purpose.) We check that these times are correct by comparing
+   against our solution. *)
+
+let test_laziness tests student sols =
+  let tests = List.map instrument tests in
+  tests |> List.iter (fun (c : mono comp) ->
+    let expected_behavior =
+      Ok (
+        reset();
+        I.eval_comp solution c
+        |> Solution.sols
+        |> Seq.map snapshot
+        |> Seq.take depth |> Seq.to_list
+      )
+    in
+    let actual_behavior =
+      T.result (fun () ->
+        reset();
+        I.eval_comp student c
+        |> sols
+        |> Seq.map snapshot
+        |> Seq.take depth |> Seq.to_list
+      )
+    in
+    black_box_compare
+      (=) show_list_int_int
+      [ R.Text "Some computations take place too early." ]
+      (P.show_comp_sols_snapshot_take depth) c
+      actual_behavior
+      expected_behavior
+  );
+  (* Success. *)
+  let points = 1 in
+  let msg = "The code seems lazy." in
+  [ R.success points msg ]
+
+(* Combine the above two phases. *)
+
+let test_both tests student sols =
+  section "Functional correctness" (
+    protect (fun () ->
+      test_correctness tests student sols
+    )
+  ) -@> fun () ->
+  section "Laziness" (
+    protect (fun () ->
+      test_laziness tests student sols
+    )
+  )
+
+(* -------------------------------------------------------------------------- *)
+
+(* Question 1. *)
+
+(* Grading the core functions: [return], [>>=], [fail], [choose], [sols]. *)
+
+let grab_core k =
+  (* Grab the student's five basic functions. *)
+  grab [%ty: mono -> mono m] "return" (fun return ->
+  grab [%ty: mono m -> (mono -> mono m) -> mono m] ">>=" (fun (>>=) ->
+  grab [%ty: mono m] "fail" (fun fail ->
+  grab [%ty: mono m -> mono m -> mono m] "choose" (fun choose ->
+  grab [%ty: mono m -> mono Seq.t] "sols" (fun sols ->
+  let module S = struct
+    let return = return
+    let (>>=) = (>>=)
+    let fail = fail
+    let choose = choose
+    let at_most_once = None
+    let interleave = None
+    let (>>-) = None
+  end in
+  let student = (module S : REQUIRED) in
+  k student sols
+  )))))
+
+let test_core () =
+  section "Question 1" (
+    grab_core (fun student sols ->
+      (* Generate test cases. *)
+      let tests = Feat.sample 1000 4 (DSLGen.q1 0) in
+      (* Test. *)
+      test_both tests student sols
+    )
+  )
+
+(* -------------------------------------------------------------------------- *)
+
+(* Question 2. *)
+
+(* Grading [at_most_once]. *)
+
+let grab_at_most_once k =
+  grab_core (fun student sols ->
+  grab [%ty: mono m -> mono m] "at_most_once" (fun candidate ->
+  let module S = struct
+    include (val student : REQUIRED)
+    let at_most_once = Some candidate
+  end in
+  let student = (module S : REQUIRED) in
+  k student sols
+  ))
+
+let test_at_most_once () =
+  section "Question 2" (
+    grab_at_most_once (fun student sols ->
+      (* Generate test cases. *)
+      let tests = Feat.sample 1000 4 (DSLGen.q2 0) in
+      (* Test. *)
+      test_both tests student sols
+    )
+  )
+
+(* -------------------------------------------------------------------------- *)
+
+(* Question 3. *)
+
+(* Grading [interleave]. *)
+
+let grab_interleave k =
+  grab_at_most_once (fun student sols ->
+  grab [%ty: mono m -> mono m -> mono m] "interleave" (fun candidate ->
+  let module S = struct
+    include (val student : REQUIRED)
+    let interleave = Some candidate
+  end in
+  let student = (module S : REQUIRED) in
+  k student sols
+  ))
+
+let test_interleave () =
+  section "Question 3" (
+    grab_interleave (fun student sols ->
+      (* Generate test cases. *)
+      let tests = Feat.sample 1000 4 (DSLGen.q3 0) in
+      (* Test. *)
+      test_both tests student sols
+    )
+  )
+
+(* -------------------------------------------------------------------------- *)
+
+(* Question 4. *)
+
+(* Grading [>>-]. *)
+
+let grab_fair_bind k =
+  grab_interleave (fun student sols ->
+  grab [%ty: mono m -> (mono -> mono m) -> mono m] ">>-" (fun candidate ->
+  let module S = struct
+    include (val student : REQUIRED)
+    let (>>-) = Some candidate
+  end in
+  let student = (module S : REQUIRED) in
+  k student sols
+  ))
+
+let test_fair_bind () =
+  section "Question 4" (
+    grab_fair_bind (fun student sols ->
+      (* Generate test cases. *)
+      let tests = Feat.sample 3000 5 (DSLGen.q4 0) in
+      (* Test. *)
+      test_both tests student sols
+    )
+  )
+
+(* -------------------------------------------------------------------------- *)
+
+(* Main. *)
+
+let report () =
+  test_core() -@>
+  test_at_most_once -@>
+  test_interleave -@>
+  test_fair_bind -@>
+  fun () -> []
+
+let () =
+  T.set_result (T.ast_sanity_check code_ast report)

--- a/exercises/nondet_monad_defun/wrong/at_most_once_return_twice.log
+++ b/exercises/nondet_monad_defun/wrong/at_most_once_return_twice.log
@@ -1,0 +1,2 @@
+Learnocaml v.0.10 running.
+[ Loading the prelude. ][K[ Preparing the test environment. ][K[ Loading your code. ][K[ Loading the solution. ][K[ Preparing to launch the tests. ][K[ Launching the test bench. ][K.                              - Failure - 2 points

--- a/exercises/nondet_monad_defun/wrong/at_most_once_return_twice.ml
+++ b/exercises/nondet_monad_defun/wrong/at_most_once_return_twice.ml
@@ -1,0 +1,118 @@
+(* The following four constructor functions are implemented already. *)
+
+let return (x : 'a) : 'a m =
+  MReturn x
+
+let (>>=) (m1 : 'a m) (m2 : 'a -> 'b m) : 'b m =
+  MBind (m1, m2)
+
+let fail : 'a m =
+  MFail
+
+let choose (m1 : 'a m) (m2 : 'a m) : 'a m =
+  MChoose (m1, m2)
+
+(* The bulk of the work is to implement an interpreter for each of the
+   data types [_ failure], [(_, _) success], and [_ m]. *)
+
+let rec apply_failure : type answer . answer failure -> unit -> answer =
+  fun f () ->
+    match f with
+    | FChoose (m2, s, f) ->
+        (* Invoked when the left branch of a choice has failed.
+           [m2] is the right branch of the choice.
+           [s] and [f] are the continuations of the choice. *)
+        compute m2 s f
+    | FSols ->
+        (* Used at the top level of [sols].
+           Invoked when there is no result. *)
+        Seq.Nil
+    | FSplit ->
+        (* Used at the top level of [msplit].
+           Invoked when there is no result. *)
+        None
+
+and apply_success : type a answer .
+  (a, answer) success -> a -> answer failure -> answer
+=
+  fun s x f ->
+    match s with
+    | SBind (m2, s) ->
+        (* Invoked when the left branch of a sequence produces a result [x].
+           [m2] is the right-hand side of the sequence.
+           [s] is the success continuation of the sequence. *)
+        compute (m2 x) s f
+    | SSols ->
+        (* Used at the top level of [sols].
+           Invoked when the computation produces a result [x]. *)
+        (* Hint: construct a sequence whose head is [x] and whose
+                 tail is [f], converted to the type of a sequence.
+                 There is an easy way of performing this conversion. *)
+        Seq.Cons (x, apply_failure f)
+    | SSplit ->
+        (* Used at the top level of [msplit].
+           Invoked when the computation produces a result [x]. *)
+        (* Hint: construct an optional-pair whose first component is [x]
+                 and whose second component is [f], converted to the type
+                 of a computation. There is an easy way of performing this
+                 conversion.  *)
+        Some (x, MReflect f)
+
+and compute : type a answer .
+  a m -> (a, answer) success -> answer failure -> answer
+=
+  fun m s f ->
+    match m with
+    | MDelay m ->
+        compute (m()) s f
+    | MReturn x ->
+        apply_success s x f
+    | MBind (m1, m2) ->
+        compute m1 (SBind (m2, s)) f
+    | MFail ->
+        apply_failure f ()
+    | MChoose (m1, m2) ->
+        compute m1 s (FChoose (m2, s, f))
+    | MReflect k ->
+        match apply_failure k () with
+        | None ->
+            apply_failure f ()
+            (* inlined version of [compute fail s f] *)
+        | Some (x, m) ->
+            apply_success s x (FChoose (m, s, f))
+            (* inlined version of [compute (choose (return x) m) s f] *)
+
+let sols (m : 'a m) : 'a Seq.t =
+  fun () ->
+    compute m SSols FSols
+
+let msplit (m : 'a m) : unit -> ('a * 'a m) option =
+  fun () ->
+    compute m SSplit FSplit
+
+let at_most_once (m : 'a m) : 'a m =
+  delay (fun () ->
+    match msplit m () with
+    | None ->
+        fail
+    | Some (x, _) ->
+        choose (return x) (return x)
+  )
+
+let rec interleave (m1 : 'a m) (m2 : 'a m) : 'a m =
+  delay (fun () ->
+    match msplit m1 () with
+    | None ->
+        m2
+    | Some (x1, m1) ->
+        choose (return x1) (interleave m2 m1)
+  )
+
+let rec (>>-) (m1 : 'a m) (m2 : 'a -> 'b m) : 'b m =
+  delay (fun () ->
+    match msplit m1 () with
+    | None ->
+        fail
+    | Some (x1, m1) ->
+        interleave (m2 x1) (m1 >>- m2)
+  )

--- a/exercises/nondet_monad_defun/wrong/at_most_once_return_twice.report.txt
+++ b/exercises/nondet_monad_defun/wrong/at_most_once_return_twice.report.txt
@@ -1,0 +1,23 @@
+Question 1
+  Found [return] with compatible type.
+  Found [>>=] with compatible type.
+  Found [fail] with compatible type.
+  Found [choose] with compatible type.
+  Found [sols] with compatible type.
+  Functional correctness
+    Success 1: The code seems correct. Tested 2411 scenarios.
+  Laziness
+    Success 1: The code seems lazy.
+Question 2
+  Found [return] with compatible type.
+  Found [>>=] with compatible type.
+  Found [fail] with compatible type.
+  Found [choose] with compatible type.
+  Found [sols] with compatible type.
+  Found [at_most_once] with compatible type.
+  Functional correctness
+    Failure: Something is wrong. The following expression:
+      
+       | sols (at_most_once (return 0)) |> Seq.take 20 |> Seq.to_list
+      produces the following result: [[0; 0]] This is invalid. Producing the
+      following result is valid: [[0]]

--- a/exercises/nondet_monad_defun/wrong/choose_wrong_cont.log
+++ b/exercises/nondet_monad_defun/wrong/choose_wrong_cont.log
@@ -1,0 +1,2 @@
+Learnocaml v.0.10 running.
+[ Loading the prelude. ][K[ Preparing the test environment. ][K[ Loading your code. ][K[ Loading the solution. ][K[ Preparing to launch the tests. ][K[ Launching the test bench. ][K.                              - Failure - 0 points

--- a/exercises/nondet_monad_defun/wrong/choose_wrong_cont.ml
+++ b/exercises/nondet_monad_defun/wrong/choose_wrong_cont.ml
@@ -1,0 +1,118 @@
+(* The following four constructor functions are implemented already. *)
+
+let return (x : 'a) : 'a m =
+  MReturn x
+
+let (>>=) (m1 : 'a m) (m2 : 'a -> 'b m) : 'b m =
+  MBind (m1, m2)
+
+let fail : 'a m =
+  MFail
+
+let choose (m1 : 'a m) (m2 : 'a m) : 'a m =
+  MChoose (m1, m2)
+
+(* The bulk of the work is to implement an interpreter for each of the
+   data types [_ failure], [(_, _) success], and [_ m]. *)
+
+let rec apply_failure : type answer . answer failure -> unit -> answer =
+  fun f () ->
+    match f with
+    | FChoose (m2, s, _ (* wrong *)) ->
+        (* Invoked when the left branch of a choice has failed.
+           [m2] is the right branch of the choice.
+           [s] and [f] are the continuations of the choice. *)
+        compute m2 s f
+    | FSols ->
+        (* Used at the top level of [sols].
+           Invoked when there is no result. *)
+        Seq.Nil
+    | FSplit ->
+        (* Used at the top level of [msplit].
+           Invoked when there is no result. *)
+        None
+
+and apply_success : type a answer .
+  (a, answer) success -> a -> answer failure -> answer
+=
+  fun s x f ->
+    match s with
+    | SBind (m2, s) ->
+        (* Invoked when the left branch of a sequence produces a result [x].
+           [m2] is the right-hand side of the sequence.
+           [s] is the success continuation of the sequence. *)
+        compute (m2 x) s f
+    | SSols ->
+        (* Used at the top level of [sols].
+           Invoked when the computation produces a result [x]. *)
+        (* Hint: construct a sequence whose head is [x] and whose
+                 tail is [f], converted to the type of a sequence.
+                 There is an easy way of performing this conversion. *)
+        Seq.Cons (x, apply_failure f)
+    | SSplit ->
+        (* Used at the top level of [msplit].
+           Invoked when the computation produces a result [x]. *)
+        (* Hint: construct an optional-pair whose first component is [x]
+                 and whose second component is [f], converted to the type
+                 of a computation. There is an easy way of performing this
+                 conversion.  *)
+        Some (x, MReflect f)
+
+and compute : type a answer .
+  a m -> (a, answer) success -> answer failure -> answer
+=
+  fun m s f ->
+    match m with
+    | MDelay m ->
+        compute (m()) s f
+    | MReturn x ->
+        apply_success s x f
+    | MBind (m1, m2) ->
+        compute m1 (SBind (m2, s)) f
+    | MFail ->
+        apply_failure f ()
+    | MChoose (m1, m2) ->
+        compute m1 s (FChoose (m2, s, f))
+    | MReflect k ->
+        match apply_failure k () with
+        | None ->
+            apply_failure f ()
+            (* inlined version of [compute fail s f] *)
+        | Some (x, m) ->
+            apply_success s x (FChoose (m, s, f))
+            (* inlined version of [compute (choose (return x) m) s f] *)
+
+let sols (m : 'a m) : 'a Seq.t =
+  fun () ->
+    compute m SSols FSols
+
+let msplit (m : 'a m) : unit -> ('a * 'a m) option =
+  fun () ->
+    compute m SSplit FSplit
+
+let at_most_once (m : 'a m) : 'a m =
+  delay (fun () ->
+    match msplit m () with
+    | None ->
+        fail
+    | Some (x, _) ->
+        return x
+  )
+
+let rec interleave (m1 : 'a m) (m2 : 'a m) : 'a m =
+  delay (fun () ->
+    match msplit m1 () with
+    | None ->
+        m2
+    | Some (x1, m1) ->
+        choose (return x1) (interleave m2 m1)
+  )
+
+let rec (>>-) (m1 : 'a m) (m2 : 'a -> 'b m) : 'b m =
+  delay (fun () ->
+    match msplit m1 () with
+    | None ->
+        fail
+    | Some (x1, m1) ->
+        interleave (m2 x1) (m1 >>- m2)
+  )

--- a/exercises/nondet_monad_defun/wrong/choose_wrong_cont.report.txt
+++ b/exercises/nondet_monad_defun/wrong/choose_wrong_cont.report.txt
@@ -1,0 +1,13 @@
+Question 1
+  Found [return] with compatible type.
+  Found [>>=] with compatible type.
+  Found [fail] with compatible type.
+  Found [choose] with compatible type.
+  Found [sols] with compatible type.
+  Functional correctness
+    Failure: Something is wrong. The following expression:
+      
+       | sols (choose (return 0) (return 0)) |> Seq.take 20 |> Seq.to_list
+      produces the following result: [[0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0;
+      0; 0; 0; 0; 0; 0; 0]] This is invalid. Producing the following result
+      is valid: [[0; 0]]

--- a/exercises/nondet_monad_defun/wrong/reflect_always_fail.log
+++ b/exercises/nondet_monad_defun/wrong/reflect_always_fail.log
@@ -1,0 +1,2 @@
+Learnocaml v.0.10 running.
+[ Loading the prelude. ][K[ Preparing the test environment. ][K[ Loading your code. ][K[ Loading the solution. ][K[ Preparing to launch the tests. ][K[ Launching the test bench. ][K.                              - Failure - 4 points

--- a/exercises/nondet_monad_defun/wrong/reflect_always_fail.ml
+++ b/exercises/nondet_monad_defun/wrong/reflect_always_fail.ml
@@ -1,0 +1,112 @@
+(* The following four constructor functions are implemented already. *)
+
+let return (x : 'a) : 'a m =
+  MReturn x
+
+let (>>=) (m1 : 'a m) (m2 : 'a -> 'b m) : 'b m =
+  MBind (m1, m2)
+
+let fail : 'a m =
+  MFail
+
+let choose (m1 : 'a m) (m2 : 'a m) : 'a m =
+  MChoose (m1, m2)
+
+(* The bulk of the work is to implement an interpreter for each of the
+   data types [_ failure], [(_, _) success], and [_ m]. *)
+
+let rec apply_failure : type answer . answer failure -> unit -> answer =
+  fun f () ->
+    match f with
+    | FChoose (m2, s, f) ->
+        (* Invoked when the left branch of a choice has failed.
+           [m2] is the right branch of the choice.
+           [s] and [f] are the continuations of the choice. *)
+        compute m2 s f
+    | FSols ->
+        (* Used at the top level of [sols].
+           Invoked when there is no result. *)
+        Seq.Nil
+    | FSplit ->
+        (* Used at the top level of [msplit].
+           Invoked when there is no result. *)
+        None
+
+and apply_success : type a answer .
+  (a, answer) success -> a -> answer failure -> answer
+=
+  fun s x f ->
+    match s with
+    | SBind (m2, s) ->
+        (* Invoked when the left branch of a sequence produces a result [x].
+           [m2] is the right-hand side of the sequence.
+           [s] is the success continuation of the sequence. *)
+        compute (m2 x) s f
+    | SSols ->
+        (* Used at the top level of [sols].
+           Invoked when the computation produces a result [x]. *)
+        (* Hint: construct a sequence whose head is [x] and whose
+                 tail is [f], converted to the type of a sequence.
+                 There is an easy way of performing this conversion. *)
+        Seq.Cons (x, apply_failure f)
+    | SSplit ->
+        (* Used at the top level of [msplit].
+           Invoked when the computation produces a result [x]. *)
+        (* Hint: construct an optional-pair whose first component is [x]
+                 and whose second component is [f], converted to the type
+                 of a computation. There is an easy way of performing this
+                 conversion.  *)
+        Some (x, MReflect f)
+
+and compute : type a answer .
+  a m -> (a, answer) success -> answer failure -> answer
+=
+  fun m s f ->
+    match m with
+    | MDelay m ->
+        compute (m()) s f
+    | MReturn x ->
+        apply_success s x f
+    | MBind (m1, m2) ->
+        compute m1 (SBind (m2, s)) f
+    | MFail ->
+        apply_failure f ()
+    | MChoose (m1, m2) ->
+        compute m1 s (FChoose (m2, s, f))
+    | MReflect k ->
+       apply_failure f () (* wrong: always fail *)
+
+let sols (m : 'a m) : 'a Seq.t =
+  fun () ->
+    compute m SSols FSols
+
+let msplit (m : 'a m) : unit -> ('a * 'a m) option =
+  fun () ->
+    compute m SSplit FSplit
+
+let at_most_once (m : 'a m) : 'a m =
+  delay (fun () ->
+    match msplit m () with
+    | None ->
+        fail
+    | Some (x, _) ->
+        return x
+  )
+
+let rec interleave (m1 : 'a m) (m2 : 'a m) : 'a m =
+  delay (fun () ->
+    match msplit m1 () with
+    | None ->
+        m2
+    | Some (x1, m1) ->
+        choose (return x1) (interleave m2 m1)
+  )
+
+let rec (>>-) (m1 : 'a m) (m2 : 'a -> 'b m) : 'b m =
+  delay (fun () ->
+    match msplit m1 () with
+    | None ->
+        fail
+    | Some (x1, m1) ->
+        interleave (m2 x1) (m1 >>- m2)
+  )

--- a/exercises/nondet_monad_defun/wrong/reflect_always_fail.report.txt
+++ b/exercises/nondet_monad_defun/wrong/reflect_always_fail.report.txt
@@ -1,0 +1,37 @@
+Question 1
+  Found [return] with compatible type.
+  Found [>>=] with compatible type.
+  Found [fail] with compatible type.
+  Found [choose] with compatible type.
+  Found [sols] with compatible type.
+  Functional correctness
+    Success 1: The code seems correct. Tested 2411 scenarios.
+  Laziness
+    Success 1: The code seems lazy.
+Question 2
+  Found [return] with compatible type.
+  Found [>>=] with compatible type.
+  Found [fail] with compatible type.
+  Found [choose] with compatible type.
+  Found [sols] with compatible type.
+  Found [at_most_once] with compatible type.
+  Functional correctness
+    Success 1: The code seems correct. Tested 2486 scenarios.
+  Laziness
+    Success 1: The code seems lazy.
+Question 3
+  Found [return] with compatible type.
+  Found [>>=] with compatible type.
+  Found [fail] with compatible type.
+  Found [choose] with compatible type.
+  Found [sols] with compatible type.
+  Found [at_most_once] with compatible type.
+  Found [interleave] with compatible type.
+  Functional correctness
+    Failure: Something is wrong. The following expression:
+      
+       | sols (interleave (return 0) (choose (return 0) (return 0)))
+       | |> Seq.take 20
+       | |> Seq.to_list
+      produces the following result: [[0; 0]] This is invalid. Producing the
+      following result is valid: [[0; 0; 0]]

--- a/exercises/nondet_monad_defun/wrong/reflect_skip_return.log
+++ b/exercises/nondet_monad_defun/wrong/reflect_skip_return.log
@@ -1,0 +1,2 @@
+Learnocaml v.0.10 running.
+[ Loading the prelude. ][K[ Preparing the test environment. ][K[ Loading your code. ][K[ Loading the solution. ][K[ Preparing to launch the tests. ][K[ Launching the test bench. ][K.                              - Failure - 4 points

--- a/exercises/nondet_monad_defun/wrong/reflect_skip_return.ml
+++ b/exercises/nondet_monad_defun/wrong/reflect_skip_return.ml
@@ -1,0 +1,117 @@
+(* The following four constructor functions are implemented already. *)
+
+let return (x : 'a) : 'a m =
+  MReturn x
+
+let (>>=) (m1 : 'a m) (m2 : 'a -> 'b m) : 'b m =
+  MBind (m1, m2)
+
+let fail : 'a m =
+  MFail
+
+let choose (m1 : 'a m) (m2 : 'a m) : 'a m =
+  MChoose (m1, m2)
+
+(* The bulk of the work is to implement an interpreter for each of the
+   data types [_ failure], [(_, _) success], and [_ m]. *)
+
+let rec apply_failure : type answer . answer failure -> unit -> answer =
+  fun f () ->
+    match f with
+    | FChoose (m2, s, f) ->
+        (* Invoked when the left branch of a choice has failed.
+           [m2] is the right branch of the choice.
+           [s] and [f] are the continuations of the choice. *)
+        compute m2 s f
+    | FSols ->
+        (* Used at the top level of [sols].
+           Invoked when there is no result. *)
+        Seq.Nil
+    | FSplit ->
+        (* Used at the top level of [msplit].
+           Invoked when there is no result. *)
+        None
+
+and apply_success : type a answer .
+  (a, answer) success -> a -> answer failure -> answer
+=
+  fun s x f ->
+    match s with
+    | SBind (m2, s) ->
+        (* Invoked when the left branch of a sequence produces a result [x].
+           [m2] is the right-hand side of the sequence.
+           [s] is the success continuation of the sequence. *)
+        compute (m2 x) s f
+    | SSols ->
+        (* Used at the top level of [sols].
+           Invoked when the computation produces a result [x]. *)
+        (* Hint: construct a sequence whose head is [x] and whose
+                 tail is [f], converted to the type of a sequence.
+                 There is an easy way of performing this conversion. *)
+        Seq.Cons (x, apply_failure f)
+    | SSplit ->
+        (* Used at the top level of [msplit].
+           Invoked when the computation produces a result [x]. *)
+        (* Hint: construct an optional-pair whose first component is [x]
+                 and whose second component is [f], converted to the type
+                 of a computation. There is an easy way of performing this
+                 conversion.  *)
+        Some (x, MReflect f)
+
+and compute : type a answer .
+  a m -> (a, answer) success -> answer failure -> answer
+=
+  fun m s f ->
+    match m with
+    | MDelay m ->
+        compute (m()) s f
+    | MReturn x ->
+        apply_success s x f
+    | MBind (m1, m2) ->
+        compute m1 (SBind (m2, s)) f
+    | MFail ->
+        apply_failure f ()
+    | MChoose (m1, m2) ->
+        compute m1 s (FChoose (m2, s, f))
+    | MReflect k ->
+        match apply_failure k () with
+        | None ->
+            apply_failure f ()
+            (* inlined version of [compute fail s f] *)
+        | Some (x, m) ->
+            compute m s f (* wrong: skip returning [x] *)
+
+let sols (m : 'a m) : 'a Seq.t =
+  fun () ->
+    compute m SSols FSols
+
+let msplit (m : 'a m) : unit -> ('a * 'a m) option =
+  fun () ->
+    compute m SSplit FSplit
+
+let at_most_once (m : 'a m) : 'a m =
+  delay (fun () ->
+    match msplit m () with
+    | None ->
+        fail
+    | Some (x, _) ->
+        return x
+  )
+
+let rec interleave (m1 : 'a m) (m2 : 'a m) : 'a m =
+  delay (fun () ->
+    match msplit m1 () with
+    | None ->
+        m2
+    | Some (x1, m1) ->
+        choose (return x1) (interleave m2 m1)
+  )
+
+let rec (>>-) (m1 : 'a m) (m2 : 'a -> 'b m) : 'b m =
+  delay (fun () ->
+    match msplit m1 () with
+    | None ->
+        fail
+    | Some (x1, m1) ->
+        interleave (m2 x1) (m1 >>- m2)
+  )

--- a/exercises/nondet_monad_defun/wrong/reflect_skip_return.report.txt
+++ b/exercises/nondet_monad_defun/wrong/reflect_skip_return.report.txt
@@ -1,0 +1,37 @@
+Question 1
+  Found [return] with compatible type.
+  Found [>>=] with compatible type.
+  Found [fail] with compatible type.
+  Found [choose] with compatible type.
+  Found [sols] with compatible type.
+  Functional correctness
+    Success 1: The code seems correct. Tested 2411 scenarios.
+  Laziness
+    Success 1: The code seems lazy.
+Question 2
+  Found [return] with compatible type.
+  Found [>>=] with compatible type.
+  Found [fail] with compatible type.
+  Found [choose] with compatible type.
+  Found [sols] with compatible type.
+  Found [at_most_once] with compatible type.
+  Functional correctness
+    Success 1: The code seems correct. Tested 2486 scenarios.
+  Laziness
+    Success 1: The code seems lazy.
+Question 3
+  Found [return] with compatible type.
+  Found [>>=] with compatible type.
+  Found [fail] with compatible type.
+  Found [choose] with compatible type.
+  Found [sols] with compatible type.
+  Found [at_most_once] with compatible type.
+  Found [interleave] with compatible type.
+  Functional correctness
+    Failure: Something is wrong. The following expression:
+      
+       | sols (interleave (return 0) (choose (return 0) (return 0)))
+       | |> Seq.take 20
+       | |> Seq.to_list
+      produces the following result: [[0; 0]] This is invalid. Producing the
+      following result is valid: [[0; 0; 0]]

--- a/exercises/nondet_monad_defun/wrong/template.log
+++ b/exercises/nondet_monad_defun/wrong/template.log
@@ -1,0 +1,2 @@
+Learnocaml v.0.10 running.
+[ Loading the prelude. ][K[ Preparing the test environment. ][K[ Loading your code. ][K[ Loading the solution. ][K[ Preparing to launch the tests. ][K[ Launching the test bench. ][K.                              - Failure - 0 points

--- a/exercises/nondet_monad_defun/wrong/template.ml
+++ b/exercises/nondet_monad_defun/wrong/template.ml
@@ -1,0 +1,110 @@
+(* The following four constructor functions are implemented already. *)
+
+let return (x : 'a) : 'a m =
+  MReturn x
+
+let (>>=) (m1 : 'a m) (m2 : 'a -> 'b m) : 'b m =
+  MBind (m1, m2)
+
+let fail : 'a m =
+  MFail
+
+let choose (m1 : 'a m) (m2 : 'a m) : 'a m =
+  MChoose (m1, m2)
+
+(* The bulk of the work is to implement an interpreter for each of the
+   data types [_ failure], [(_, _) success], and [_ m]. *)
+
+let rec apply_failure : type answer . answer failure -> unit -> answer =
+  fun f () ->
+    match f with
+    | FChoose (m2, s, f) ->
+        (* Invoked when the left branch of a choice has failed.
+           [m2] is the right branch of the choice.
+           [s] and [f] are the continuations of the choice. *)
+        raise TODO (* one line *)
+    | FSols ->
+        (* Used at the top level of [sols].
+           Invoked when there is no result. *)
+        raise TODO (* one line *)
+    | FSplit ->
+        (* Used at the top level of [msplit].
+           Invoked when there is no result. *)
+        raise TODO (* one line *)
+
+and apply_success : type a answer .
+  (a, answer) success -> a -> answer failure -> answer
+=
+  fun s x f ->
+    match s with
+    | SBind (m2, s) ->
+        (* Invoked when the left branch of a sequence produces a result [x].
+           [m2] is the right-hand side of the sequence.
+           [s] is the success continuation of the sequence. *)
+        raise TODO (* one line *)
+    | SSols ->
+        (* Used at the top level of [sols].
+           Invoked when the computation produces a result [x]. *)
+        (* Hint: construct a sequence whose head is [x] and whose
+                 tail is [f], converted to the type of a sequence.
+                 There is an easy way of performing this conversion. *)
+        raise TODO (* one line *)
+    | SSplit ->
+        (* Used at the top level of [msplit].
+           Invoked when the computation produces a result [x]. *)
+        (* Hint: construct an optional-pair whose first component is [x]
+                 and whose second component is [f], converted to the type
+                 of a computation. There is an easy way of performing this
+                 conversion.  *)
+        raise TODO (* one line *)
+
+and compute : type a answer .
+  a m -> (a, answer) success -> answer failure -> answer
+=
+  fun m s f ->
+    match m with
+    | MDelay m ->
+        (* Hint: evaluate [m()] and continue. *)
+        raise TODO (* one line *)
+    | MReturn x ->
+        (* Hint: successfully produce the result [x]. *)
+        raise TODO (* one line *)
+    | MBind (m1, m2) ->
+        (* Hint: enter the left-hand side [m1] with an
+                 appropriate success continuation. *)
+        raise TODO (* one line *)
+    | MFail ->
+        (* Hint: fail. *)
+        raise TODO (* one line *)
+    | MChoose (m1, m2) ->
+        (* Hint: enter the left-hand side [m1] with an
+                 appropriate failure continuation. *)
+        raise TODO (* one line *)
+    | MReflect k ->
+        (* We have a failure continuation [k], which was captured earlier and
+           wrapped with [MReflect] so as to disguise it as a computation. We are
+           now asked to execute this computation. Thus, we must call this
+           failure continuation, whose answer type is [('a * 'a m) option].
+           Depending on whether this yields [None] or [Some (x, m)], we must
+           behave either like [fail] or like [choose (return x) m]. *)
+        raise TODO (* five lines *)
+
+let sols (m : 'a m) : 'a Seq.t =
+  (* TO DO: Define this function. *)
+  raise TODO (* one line *)
+
+let msplit (m : 'a m) : unit -> ('a * 'a m) option =
+  (* TO DO: Define this function. *)
+  raise TODO (* one line *)
+
+let at_most_once (m : 'a m) : 'a m =
+  (* TO DO: Define this function. *)
+  raise TODO
+
+let rec interleave (m1 : 'a m) (m2 : 'a m) : 'a m =
+  (* TO DO: Define this function. *)
+  raise TODO
+
+let rec (>>-) (m1 : 'a m) (m2 : 'a -> 'b m) : 'b m =
+  (* TO DO: Define this function. *)
+  raise TODO

--- a/exercises/nondet_monad_defun/wrong/template.report.txt
+++ b/exercises/nondet_monad_defun/wrong/template.report.txt
@@ -1,0 +1,8 @@
+Question 1
+  Found [return] with compatible type.
+  Found [>>=] with compatible type.
+  Found [fail] with compatible type.
+  Found [choose] with compatible type.
+  Found [sols] with compatible type.
+  Functional correctness
+    Failure: Not yet implemented.

--- a/exercises/nondet_monad_seq/AUTHOR
+++ b/exercises/nondet_monad_seq/AUTHOR
@@ -1,0 +1,1 @@
+François Pottier

--- a/exercises/nondet_monad_seq/Makefile
+++ b/exercises/nondet_monad_seq/Makefile
@@ -1,0 +1,2 @@
+LIB   := $(shell cd ../lib && pwd)
+include $(LIB)/Makefile

--- a/exercises/nondet_monad_seq/TODO
+++ b/exercises/nondet_monad_seq/TODO
@@ -1,0 +1,19 @@
+-- about this exercise ---------------------------------------------------------
+
+* Add a link to the exercise where the nondeterminism monad is used.
+
+* Should `fix` be part of the constructors?
+  How do we define `nats`?
+
+* Should also test computations that are expected to produce an infinite
+  number of results. E.g., grade `nats`.
+
+* The error messages that are produced when the code is not lazy (too eager)
+  are admittedly cryptic. Could we produce a better explanation?
+
+-- ocaml questions -------------------------------------------------------------
+
+-- learn-ocaml questions -------------------------------------------------------
+
+* Some tests that succeed when run in batch mode
+  fail with `Stack_overflow` when run in Firefox.

--- a/exercises/nondet_monad_seq/attic.ml
+++ b/exercises/nondet_monad_seq/attic.ml
@@ -1,0 +1,22 @@
+(* -------------------------------------------------------------------------- *)
+
+(* Comparing and printing sequences. *)
+
+module SeqExtra = struct
+
+  let equal_upto depth xs ys =
+    Seq.equal (=) (Seq.take depth xs) (Seq.take depth ys)
+
+  let print_upto print_element depth xs =
+    let rec contents depth xs =
+      match depth, xs() with
+      | _, Seq.Nil ->
+          []
+      | 0, Seq.Cons _ ->
+          [ utf8string "..." ]
+      | _, Seq.Cons (x, xs) ->
+          print_element x :: contents (depth - 1) xs
+    in
+    group (semis (contents depth xs))
+
+end

--- a/exercises/nondet_monad_seq/descr.md
+++ b/exercises/nondet_monad_seq/descr.md
@@ -1,0 +1,399 @@
+# Implementing Nondeterminism with Sequences
+
+In this exercise, we build an implementation of the nondeterminism
+monad. This monad admits several possible implementations; the one
+that we choose here is a direct implementation where a computation
+is represented as an on-demand sequence of values.
+
+## The Nondeterminism Monad
+
+When searching for the solution of a problem, one must typically
+explore multiple choices. If a series of choices lead to a failure
+(a dead end), then one must backtrack and explore another avenue.
+
+There are a number of ways in which nondeterminism and backtracking
+can be implemented. Regardless of which implementation mechanism is
+chosen, it is desirable to hide it behind an abstraction barrier and
+present the end user with **a simple API for constructing an executing
+nondeterministic computations**.
+
+This API is known as the **nondeterminism monad**. It offers the
+following key elements:
+
+* A type `'a m`, the type of computations that yield results of type
+ `'a`.
+
+* A number of constructor functions for constructing computations,
+  such as `fail: 'a m`, which represents failure, and `choose: 'a m
+  -> 'a m -> 'a m`, which expresses a nondeterministic choice
+  between two computations.
+
+* A single observation function, `sols: 'a m -> 'a Seq.t`, which
+  converts a computation to a sequence of results, thereby allowing
+  the user to execute this computation and observe its results. The
+  name `sols` stands for `solutions`.
+
+A monad can be thought of as a **mini-programming language** where
+computations are first-class citizens: we have a type of
+computations, ways of building computations, and a way of executing
+computations.
+
+A computation in the nondeterminism monad can produce zero, one, or
+more results. Indeed, a computation that fails produces zero
+results. A computation that succeeds normally produces one result.
+A computation that uses `choose` can produce more than one result.
+It is in fact possible to construct computations that produce an
+infinite number of results!
+
+Thus, a useful way to think of a computation is as **a sequence of
+results**, that is, a sequence of results.
+
+Because of this remark, one might be tempted to define the type `'a
+m` as a synonym for `'a Seq.t`, the type of sequences of values of
+type `'a`. However, although it is possible to represent a
+computation internally as a sequence (and we will do so in this
+exercise), this is not necessarily the best implementation
+technique. Thus, we prefer to make the API more flexible by viewing
+`'a m` as an abstract type and by offering an observation function,
+`sols`, which converts a computation to a sequence.
+
+## The Nondeterminism Monad's API
+
+The signature, or API, of the nondeterminism monad is as follows:
+
+```
+  (* Type. *)
+  type 'a m
+
+  (* Constructor functions. *)
+  val return: 'a -> 'a m
+  val (>>=): 'a m -> ('a -> 'b m) -> 'b m
+  val fail: 'a m
+  val choose: 'a m -> 'a m -> 'a m
+  val delay: (unit -> 'a m) -> 'a m
+  val at_most_once: 'a m -> 'a m
+  val interleave: 'a m -> 'a m -> 'a m
+  val (>>-): 'a m -> ('a -> 'b m) -> 'b m
+
+  (* Observation function. *)
+  val sols: 'a m -> 'a Seq.t
+```
+
+As explained above, a value of type `'a m` is **a description of a
+computation**, which, once executed, produces a sequence of results
+of type `'a`.
+
+To execute a computation `m`, one must first convert it to a
+sequence of type `'a Seq.t`, whose elements can then be demanded,
+one by one. (More information on the module `Seq` is given below.)
+This conversion is performed by the observation function `sols`.
+
+The call `sols m` typically terminates in constant time; the actual
+computation described by `m` takes place only when the elements of
+the sequence `sols m` are demanded, and only insofar as necessary to
+produce the elements that are demanded. For instance, applying
+`Seq.head` to the sequence `sols m` forces the computation to
+proceed up to the point where it is able to produce its first
+result.
+
+The constructor functions `return` and `(>>=)` exist in all monads.
+(They are also known as `return` and `bind`.) `return` constructs a
+trivial computation, which does nothing except return a value,
+whereas `(>>=)` constructs the sequential composition of two
+computations. Together, they allow constructing the sequential
+composition of an arbitrary number of computations.
+
+* The computation `return v` succeeds exactly once with the value
+  `v`. In other words, the sequence of values that it produces is
+  the singleton sequence composed of just `v`.
+
+* The computation `m1 >>= m2` is the sequential composition of the
+  computations `m1` and `m2`. This composition operator is
+  asymmetric: whereas its first argument `m1` is a computation of
+  type `'a m`, its second argument `m2` is a function of type `a ->
+  'b m`. Every value `x` produced by `m1` is passed to `m2`,
+  yielding a computation `m2 x`. The sequence of values produced by
+  `m1 >>= m2` is the concatenation of the sequences of values
+  produced by the computations `m2 x`, where `x` ranges over the
+  values produced by `m1`.
+
+The constructor functions `fail` and `choose` are specific of the
+nondeterminism monad. `fail` can be thought of as a 0-ary
+disjunction, whereas `choose` is a binary disjunction. Together,
+they allow constructing the disjunction of an arbitrary number of
+computations.
+
+* The computation `fail` returns no result. In other words, it
+  produces an empty sequence of values.
+
+* The sequence of values produced by `choose m1 m2` is the
+  concatenation of the sequences of values produced by `m1`
+  and by `m2`.
+
+The constructor function `delay` is used to delay the construction
+of a computation until the moment where this computation must be
+executed. Indeed, a difficulty that arises in a strict programming
+language, such as OCaml, is that the arguments passed to constructor
+functions, such as `return` and `choose`, are evaluated immediately,
+at construction time. For instance, when one writes `choose e1 e2`,
+both of the OCaml expressions `e1` and `e2` are evaluated before
+`choose` is invoked. If the evaluation of `e2` performs nontrivial
+work, then this work arguably takes place too early: indeed, there
+should be no need to evaluate `e2` until all of the values produced
+by `e1` have been demanded. To remedy this, one may write `choose e1
+(delay (fun () -> e2))`. There, the expression `e2` is placed in the
+body of an anonymous function, so `e2` is not evaluated immediately.
+This anonymous function, whose type is `unit -> 'a m`,
+is converted by `delay` to a computation of type `'a m`.
+This conversion requires no serious work;
+it is performed in constant time.
+An intuitive reason why this is possible is that the type `'a m`
+represents a *suspended* computation already,
+so the type `unit -> 'a m` represents a *suspended suspended*
+computation, which is essentially the same thing; these types
+are interconvertible at no cost.
+
+The computations `e` and `delay (fun () -> e)` produce the same
+sequence of results. The only difference between them is the time at
+which the evaluation of `e` takes place: either immediately, or only
+when the first result is demanded.
+
+It is worth noting that in a lazy language, such as Haskell, there
+is no need for `delay`. In such a language, when one writes `choose
+e1 e2`, the expressions `e1` and `e2` are *not* evaluated
+immediately: they are evaluated only when their value is demanded.
+Thus, the fact that `e2` need not be evaluated until all of the
+values produced by `e1` have been demanded goes without saying. The
+fact that there is no need for explicit uses of `delay` is arguably
+a strength of lazy languages. At the same time, the fact that it is
+not obvious where laziness plays a crucial role is arguably a
+weakness of lazy languages. In OCaml, in contrast, the explicit use
+of `delay` can be verbose, but helps understand what is going on.
+
+The constructor function `at_most_once` constructs a computation
+that succeeds at most once. If `m` fails, then `at_most_once m`
+fails as well. If `m` produces a result `x`, possibly followed with
+more results, then `at_most_once m` produces just the result `x`,
+and no more. This constructor can be used to commit to a result and
+prevent any other choices from being explored. In other words, it
+limits the amount of backtracking that takes place.
+
+The constructor function `interleave` has the same type as `choose`.
+It is a *fair disjunction* operator. An ordinary disjunction `choose
+m1 m2` gives priority to its left branch: it first lets `e1` produce
+as many results as it wishes, then gives control to `e2`. This can
+be problematic: if `e1` produces a large number of results, then
+`e2` is tried very late. At an extreme, if `e1` produces an infinite
+number of results, then `e2` is never tried. For instance, supposing
+that `evens` produces the infinite sequence `0, 2, 4, ...` and
+`odds` produces the infinite sequence `1, 3, 5, ...`,
+the disjunction `choose evens odds` is equivalent to just `evens`,
+which seems counter-intuitive and undesirable. In contrast,
+`interleave` is defined in such a way that `interleave evens odd`
+produces the infinite sequence `0, 1, 2, 3, 4, 5, ...`.
+It is *fair* in the sense that each branch in turn is allowed
+to produce a result.
+
+The constructor function `(>>-)` has the same type as `(>>=)`.
+It is a *fair sequencing* operator.
+Indeed, a problem with ordinary sequencing `(>>=)` is that
+it gives rise to ordinary (unfair) disjunctions.
+To see this, suppose that the left-hand argument of `(>>=)`
+is a computation that produces `x` as its first result,
+followed with a computation `m1` that may produce more results.
+Thus, this left-hand argument is equivalent to
+`choose (return x) m1`.
+When we sequentially compose it with a computation `m2`,
+we obtain
+`(choose (return x) m1) >>= m2`,
+which is equivalent to
+`choose (return x >>= m2) (m1 >>= m2)`,
+which itself is the same as
+`choose (m2 x) (m1 >>= m2)`.
+We are faced with an ordinary (unfair) disjunction.
+The problem, again, is that if `m2 x` produces an
+infinite number of results, then `m1 >>= m2`
+is never executed.
+To remedy this problem,
+the fair sequencing operator `(>>-)`
+is defined in such a way that
+`choose (return x) m1 >>- m2`
+is equivalent to
+`interleave (m2 x) (m1 >>- m2)`.
+Thus, it gives rise to a fair disjunction.
+
+## The `Seq` API
+
+The type of **on-demand sequences** is defined in a module named `Seq`.
+Beginning with version 4.07,
+this module is part of OCaml's standard library.
+
+```
+module Seq : sig
+
+  type 'a t = unit -> 'a node
+
+  and +'a node =
+  | Nil
+  | Cons of 'a * 'a t
+
+  val nil : 'a t
+  val cons: 'a -> 'a t -> 'a t
+  val singleton: 'a -> 'a t
+
+  val map: ('a -> 'b) -> 'a t -> 'b t
+  val concat: 'a t -> 'a t -> 'a t
+  val flatten: 'a t t -> 'a t
+
+  val take: int -> 'a t -> 'a t
+
+  val head: 'a t -> 'a option
+
+  val of_list: 'a list -> 'a t
+  val to_list: 'a t -> 'a list
+
+end
+```
+
+This data type is closely related to the algebraic data type of lists.
+Indeed, if instead of `unit -> 'a node` one had written just `'a node`,
+then this data type would have been isomorphic to the type of lists.
+
+The presence of `unit -> ...` indicates that a sequence is in fact a function.
+Calling this function, by applying it to the value `()`, amounts to requesting
+the head of the sequence. This head can be either `Nil`, which means that the
+sequence is empty, or `Cons (x, xs)`, which means that the first element of
+the sequence is `x` and the remaining elements form another sequence `xs`. It
+is worth noting that `xs` is itself a function, so the elements of the
+sequence `xs` need not be explicitly computed until `xs` is applied.
+
+Sequences are closely related to *iterators* in object-oriented languages,
+such as C++ and Java. Yet, sequences are much simpler than iterators, for
+two reasons:
+
+* they involve no mutable state;
+
+* they are just as easy to construct and to use as ordinary lists.
+
+The functions `nil`, `cons`, and `singleton` are constructor functions.
+
+The functions `map`, `concat`, `flatten` are analogues for sequences
+of the standard list functions `List.map`, `(@)`, and
+`List.flatten`.
+
+The function `Seq.take` truncates a sequence at a certain length:
+`Seq.take n xs` is a sequence that begins like `xs` but has at most
+`n` elements.
+
+The function `Seq.head` demands the first element of a sequence. If
+the sequence begins with an element `x`, then `Some x` is returned;
+otherwise, `None` is returned. This forces enough computation to
+take place so as to be able to produce the first element of the
+sequence.
+
+The functions `Seq.of_list` and `Seq.to_list` convert between lists
+and sequences, both ways. One must keep in mind that applying
+`Seq.to_list` to a sequence `xs` causes all of its elements to be
+demanded: that is, it forces all of the suspended computations to
+take place. In particular, if `xs` is an infinite sequence, then
+`Seq.to_list xs` does not terminate.
+
+## Implementing the Nondeterminism Monad
+
+In this exercise, we **implement** the nondeterminism monad by
+representing a computation as a sequence of results.
+Thus, we adopt the following type definition:
+
+```
+  type 'a m = 'a Seq.t
+```
+
+This is the simplest possible manner of implementing computations.
+Indeed, we wrote above that a computation **produces** a sequence
+of results. Here, we decide that a computation **is** a sequence
+of results.
+
+**Question 1.** Implement the four constructor functions
+`return`, `(>>=)`, `fail`, and `choose`. Implement the
+observation function `sols`.
+
+*Hint.* Think of the sequence of results that the computations
+`return x`, `m1 >>= m2`, `fail`, and `choose m1 m2` are supposed to
+produce. Then, use the facilities provided by the module `Seq` to
+build these sequences. Each of these five functions can be
+implemented in one very short line.
+
+*Note.* The automated grading system first tests whether your code
+is functionally correct. To do so, it builds a computation using the
+four constructor functions, converts it to a sequence via `sols`,
+and tests whether this produces the expected sequence of results.
+Then, it tests whether your code is lazy, that is, whether each
+result is computed as late as possible. To do so, it uses a
+constructor function `tick: 'a m -> 'a m` whose effect is as
+follows: the computation `tick m` produces the same sequence of
+results as the computation `m`, and, when executed, increments a
+global counter named `work`. Thus, by executing computations that
+contain `tick`s, the automated grading system can tell when
+computations are executed. For instance, demanding just the first
+result of the computation
+`choose (tick (return 0)) (tick (return 1))` should cause `work` to
+be incremented just once, not twice.
+
+**Question 2.** Implement the constructor function `at_most_once`.
+
+**Question 3.** Implement the constructor function `interleave`.
+
+*Hint.* As a first step, you may first implement
+`interleave: 'a list -> 'a list -> 'a list`
+as an operation on lists. Perform case analysis
+on the first argument: either it is empty, or
+it is nonempty.
+
+*Hint.* Then, adapt your code so that `interleave` has the desired
+type `'a m -> 'a m -> 'a m`. The constructor function `delay` can be
+useful.
+
+**Question 4.** Implement the constructor function `(>>-)`.
+
+*Hint.* Again, perform case analysis on the first argument.
+
+## Notes
+
+This exercise is based on the paper
+**"Deriving backtracking monad transformers"**
+[(Hinze, 2000)](https://www.cs.ox.ac.uk/ralf.hinze/publications/ICFP00.ps.gz)
+and on the first part of the paper
+**"Backtracking, Interleaving, and Terminating Monad Transformers"**
+[(Kiselyov, Shan, Friedman, and Sabry, 2005)](http://okmij.org/ftp/papers/LogicT.pdf)
+(up to section 4.2).
+
+It is important to note that these papers use Haskell, a lazy programming
+language, where computations are suspended by default. Thus, where they use
+lists, we cannot use OCaml lists; we must instead use OCaml sequences.
+Furthermore, we must sometimes be careful to explicitly delay computations:
+our `delay` constructor serves this purpose.
+
+These papers go beyond us by implementing nondeterminism not just as a monad,
+but as a **monad transformer**. Monad transformers can be composed. For
+instance, by composing the nondeterminism monad transformer and the state
+monad transformer, one can describe computations that involve both
+nondeterminism and mutable state.
+
+Implementing nondeterministic computations directly as Haskell lists or as
+OCaml sequences, as we do in this exercise, is the simplest implementation. It
+is in agreement with our intuitive understanding of computations: indeed, we
+like to think of a nondeterministic computation as a process that produces a
+sequence of results.
+
+Unfortunately, this implementation is inefficient: because `choose` is
+implemented as sequence concatenation, the cost of a single use of `choose` is
+linear in the number of results produced by the left-hand side. In other
+words, in a binary tree of `choose` constructors, transmitting a result from a
+left child to its father costs O(1). In the worst case, executing the left-leaning
+computation `choose (choose (choose (... (choose 0 1) ...) (n-2)) (n-1)) n`
+has quadratic cost O(n^2), even though it produces only O(n) results.
+
+In a
+<a href="" onclick="top.location='/exercises/nondet_monad_cont/';">companion exercise</a>,
+we switch to a more efficient implementation,
+based on the use of success and failure **continuations**.

--- a/exercises/nondet_monad_seq/master.ml
+++ b/exercises/nondet_monad_seq/master.ml
@@ -1,0 +1,83 @@
+let return (x : 'a) : 'a m =
+(* BEGIN INCLUDE *)
+  (* TO DO: Define this function. *)
+  raise TODO
+(*   END INCLUDE *)
+(* BEGIN EXCLUDE
+  Seq.singleton x
+     END EXCLUDE *)
+
+let (>>=) (m1 : 'a m) (m2 : 'a -> 'b m) : 'b m =
+(* BEGIN INCLUDE *)
+  (* TO DO: Define this function. *)
+  raise TODO
+(*   END INCLUDE *)
+(* BEGIN EXCLUDE
+  m1 |> Seq.map m2 |> Seq.flatten
+     END EXCLUDE *)
+
+let fail : 'a m =
+(* BEGIN INCLUDE *)
+  (* TO DO: Define this constant. (Delete the whole line.) *)
+  delay (fun () -> raise TODO)
+(*   END INCLUDE *)
+(* BEGIN EXCLUDE
+  Seq.nil
+     END EXCLUDE *)
+
+let choose (m1 : 'a m) (m2 : 'a m) : 'a m =
+(* BEGIN INCLUDE *)
+  (* TO DO: Define this function. *)
+  raise TODO
+(*   END INCLUDE *)
+(* BEGIN EXCLUDE
+  Seq.concat m1 m2
+     END EXCLUDE *)
+
+let sols (m : 'a m) : 'a Seq.t =
+(* BEGIN INCLUDE *)
+  (* TO DO: Define this function. *)
+  raise TODO
+(*   END INCLUDE *)
+(* BEGIN EXCLUDE
+  m
+     END EXCLUDE *)
+
+let at_most_once (m : 'a m) : 'a m =
+(* BEGIN INCLUDE *)
+  (* TO DO: Define this function. *)
+  raise TODO
+(*   END INCLUDE *)
+(* BEGIN EXCLUDE
+  Seq.take 1 m
+     END EXCLUDE *)
+
+let rec interleave (m1 : 'a m) (m2 : 'a m) : 'a m =
+(* BEGIN INCLUDE *)
+  (* TO DO: Define this function. *)
+  raise TODO
+(*   END INCLUDE *)
+(* BEGIN EXCLUDE
+  delay (fun () ->
+    match m1() with
+    | Seq.Nil ->
+        m2
+    | Seq.Cons (x1, m1) ->
+        choose (return x1) (interleave m2 m1)
+  )
+     END EXCLUDE *)
+
+let rec (>>-) (m1 : 'a m) (m2 : 'a -> 'b m) : 'b m =
+(* BEGIN INCLUDE *)
+  (* TO DO: Define this function. *)
+  raise TODO
+(*   END INCLUDE *)
+(* BEGIN EXCLUDE
+  delay (fun () ->
+    match m1() with
+    | Seq.Nil ->
+        fail
+    | Seq.Cons (x1, m1) ->
+        interleave (m2 x1) (m1 >>- m2)
+  )
+     END EXCLUDE *)

--- a/exercises/nondet_monad_seq/meta.json
+++ b/exercises/nondet_monad_seq/meta.json
@@ -1,0 +1,6 @@
+{
+  "learnocaml_version":"1",
+  "kind":"exercise",
+  "stars":3,
+  "title":"Implementing Nondeterminism with Sequences"
+}

--- a/exercises/nondet_monad_seq/prelude.ml
+++ b/exercises/nondet_monad_seq/prelude.ml
@@ -1,0 +1,114 @@
+(* The module [Seq] is standard as of OCaml 4.07. *)
+
+module Seq = struct
+
+  type 'a t = unit -> 'a node
+
+  and +'a node =
+  | Nil
+  | Cons of 'a * 'a t
+
+  let nil =
+    fun () -> Nil
+
+  let cons x xs =
+    fun () -> Cons (x, xs)
+
+  let singleton x =
+    cons x nil
+
+  let rec map (f : 'a -> 'b) (xs : 'a t) : 'b t =
+    fun () ->
+      match xs() with
+      | Nil ->
+          Nil
+      | Cons (x, xs) ->
+          Cons (f x, map f xs)
+
+  let rec concat (xs : 'a t) (ys : 'a t) : 'a t =
+    fun () ->
+      match xs() with
+      | Nil ->
+          ys()
+      | Cons (x, xs) ->
+          Cons (x, concat xs ys)
+
+  let rec flatten (xss : 'a t t) : 'a t =
+    fun () ->
+      match xss() with
+      | Nil ->
+          Nil
+      | Cons (xs, xss) ->
+          concat xs (flatten xss) ()
+
+  let rec take n (xs : 'a t) : 'a t =
+    if n = 0 then
+      nil
+    else
+      fun () ->
+        match xs() with
+        | Nil ->
+            Nil
+        | Cons (x, xs) ->
+            Cons (x, take (n-1) xs)
+
+  let head (xs : 'a t) : 'a option =
+    match xs() with
+    | Nil ->
+        None
+    | Cons (x, _) ->
+        Some x
+
+  let rec of_list (xs : 'a list) : 'a t =
+    fun () ->
+      match xs with
+      | [] ->
+          Nil
+      | x :: xs ->
+          Cons (x, of_list xs)
+
+  (* A word of warning: [to_list] does not terminate if it is applied
+     to an infinite sequence. Furthermore, this version of [to_list]
+     is not tail-recursive and could exhaust the stack space if it was
+     applied to a long sequence. *)
+
+  let rec to_list (xs : 'a t) : 'a list =
+    match xs() with
+    | Nil ->
+        []
+    | Cons (x, xs) ->
+        x :: to_list xs
+
+end
+
+(* A nondeterministic computation produces a sequence of values,
+   and is represented (in this implementation) as a sequence of
+   values. *)
+
+type 'a m =
+  'a Seq.t
+
+let delay (m : unit -> 'a m) : 'a m =
+  fun () ->
+    m()()
+
+(* The effect of executing the computation [tick m] is to first increment the
+   global counter [work], then execute the computation [m]. *)
+
+(* The grading code uses these operations in order to check that computations
+   are executed on demand, that is, as late as possible. *)
+
+let work =
+  ref 0
+
+let reset() =
+  work := 0
+
+let tick (m : 'a m) : 'a m =
+  delay (fun () ->
+    work := !work + 1;
+    m
+  )
+
+let snapshot (x : 'a) : 'a * int =
+  (x, !work)

--- a/exercises/nondet_monad_seq/prepare.ml
+++ b/exercises/nondet_monad_seq/prepare.ml
@@ -1,0 +1,1 @@
+exception TODO

--- a/exercises/nondet_monad_seq/solution.log
+++ b/exercises/nondet_monad_seq/solution.log
@@ -1,0 +1,2 @@
+Learnocaml v.0.10 running.
+[ Loading the prelude. ][K[ Preparing the test environment. ][K[ Loading your code. ][K[ Loading the solution. ][K[ Preparing to launch the tests. ][K[ Launching the test bench. ][K.                              - Success - 8 points

--- a/exercises/nondet_monad_seq/solution.ml
+++ b/exercises/nondet_monad_seq/solution.ml
@@ -1,0 +1,35 @@
+let return (x : 'a) : 'a m =
+  Seq.singleton x
+
+let (>>=) (m1 : 'a m) (m2 : 'a -> 'b m) : 'b m =
+  m1 |> Seq.map m2 |> Seq.flatten
+
+let fail : 'a m =
+  Seq.nil
+
+let choose (m1 : 'a m) (m2 : 'a m) : 'a m =
+  Seq.concat m1 m2
+
+let sols (m : 'a m) : 'a Seq.t =
+  m
+
+let at_most_once (m : 'a m) : 'a m =
+  Seq.take 1 m
+
+let rec interleave (m1 : 'a m) (m2 : 'a m) : 'a m =
+  delay (fun () ->
+    match m1() with
+    | Seq.Nil ->
+        m2
+    | Seq.Cons (x1, m1) ->
+        choose (return x1) (interleave m2 m1)
+  )
+
+let rec (>>-) (m1 : 'a m) (m2 : 'a -> 'b m) : 'b m =
+  delay (fun () ->
+    match m1() with
+    | Seq.Nil ->
+        fail
+    | Seq.Cons (x1, m1) ->
+        interleave (m2 x1) (m1 >>- m2)
+  )

--- a/exercises/nondet_monad_seq/solution.report.txt
+++ b/exercises/nondet_monad_seq/solution.report.txt
@@ -1,0 +1,46 @@
+Question 1
+  Found [return] with compatible type.
+  Found [>>=] with compatible type.
+  Found [fail] with compatible type.
+  Found [choose] with compatible type.
+  Found [sols] with compatible type.
+  Functional correctness
+    Success 1: The code seems correct. Tested 2411 scenarios.
+  Laziness
+    Success 1: The code seems lazy.
+Question 2
+  Found [return] with compatible type.
+  Found [>>=] with compatible type.
+  Found [fail] with compatible type.
+  Found [choose] with compatible type.
+  Found [sols] with compatible type.
+  Found [at_most_once] with compatible type.
+  Functional correctness
+    Success 1: The code seems correct. Tested 2486 scenarios.
+  Laziness
+    Success 1: The code seems lazy.
+Question 3
+  Found [return] with compatible type.
+  Found [>>=] with compatible type.
+  Found [fail] with compatible type.
+  Found [choose] with compatible type.
+  Found [sols] with compatible type.
+  Found [at_most_once] with compatible type.
+  Found [interleave] with compatible type.
+  Functional correctness
+    Success 1: The code seems correct. Tested 2867 scenarios.
+  Laziness
+    Success 1: The code seems lazy.
+Question 4
+  Found [return] with compatible type.
+  Found [>>=] with compatible type.
+  Found [fail] with compatible type.
+  Found [choose] with compatible type.
+  Found [sols] with compatible type.
+  Found [at_most_once] with compatible type.
+  Found [interleave] with compatible type.
+  Found [>>-] with compatible type.
+  Functional correctness
+    Success 1: The code seems correct. Tested 10356 scenarios.
+  Laziness
+    Success 1: The code seems lazy.

--- a/exercises/nondet_monad_seq/template.ml
+++ b/exercises/nondet_monad_seq/template.ml
@@ -1,0 +1,31 @@
+let return (x : 'a) : 'a m =
+  (* TO DO: Define this function. *)
+  raise TODO
+
+let (>>=) (m1 : 'a m) (m2 : 'a -> 'b m) : 'b m =
+  (* TO DO: Define this function. *)
+  raise TODO
+
+let fail : 'a m =
+  (* TO DO: Define this constant. (Delete the whole line.) *)
+  delay (fun () -> raise TODO)
+
+let choose (m1 : 'a m) (m2 : 'a m) : 'a m =
+  (* TO DO: Define this function. *)
+  raise TODO
+
+let sols (m : 'a m) : 'a Seq.t =
+  (* TO DO: Define this function. *)
+  raise TODO
+
+let at_most_once (m : 'a m) : 'a m =
+  (* TO DO: Define this function. *)
+  raise TODO
+
+let rec interleave (m1 : 'a m) (m2 : 'a m) : 'a m =
+  (* TO DO: Define this function. *)
+  raise TODO
+
+let rec (>>-) (m1 : 'a m) (m2 : 'a -> 'b m) : 'b m =
+  (* TO DO: Define this function. *)
+  raise TODO

--- a/exercises/nondet_monad_seq/test.ml
+++ b/exercises/nondet_monad_seq/test.ml
@@ -1,0 +1,1530 @@
+open Printf
+let iter = List.iter
+let map = List.map
+module T = Test_lib
+module R = Report
+type report = R.t
+(* Determinism. *)
+let () = Random.init 0
+
+(* The auto-grader. *)
+
+(* -------------------------------------------------------------------------- *)
+
+(* Some of the code below should move to separate library files. *)
+
+(* -------------------------------------------------------------------------- *)
+
+(* PPrintMini. *)
+
+(* -------------------------------------------------------------------------- *)
+
+(* A type of integers with infinity. *)
+
+type requirement =
+    int (* with infinity *)
+
+(* Infinity is encoded as [max_int]. *)
+
+let infinity : requirement =
+  max_int
+
+(* Addition of integers with infinity. *)
+
+let (++) (x : requirement) (y : requirement) : requirement =
+  if x = infinity || y = infinity then
+    infinity
+  else
+    x + y
+
+(* Comparison between an integer with infinity and a normal integer. *)
+
+let (<==) (x : requirement) (y : int) =
+  x <= y
+
+(* -------------------------------------------------------------------------- *)
+
+(* The type of documents. See [PPrintEngine] for documentation. *)
+
+type document =
+  | Empty
+  | FancyString of string * int * int * int
+  | Blank of int
+  | IfFlat of document * document
+  | HardLine
+  | Cat of requirement * document * document
+  | Nest of requirement * int * document
+  | Group of requirement * document
+
+(* -------------------------------------------------------------------------- *)
+
+(* Retrieving or computing the space requirement of a document. *)
+
+let rec requirement = function
+  | Empty ->
+      0
+  | FancyString (_, _, _, len)
+  | Blank len ->
+      len
+  | IfFlat (doc1, _) ->
+      requirement doc1
+  | HardLine ->
+      infinity
+  | Cat (req, _, _)
+  | Nest (req, _, _)
+  | Group (req, _) ->
+      req
+
+(* -------------------------------------------------------------------------- *)
+
+(* Document constructors. *)
+
+let empty =
+  Empty
+
+let fancysubstring s ofs len apparent_length =
+  if len = 0 then
+    empty
+  else
+    FancyString (s, ofs, len, apparent_length)
+
+let fancystring s apparent_length =
+  fancysubstring s 0 (String.length s) apparent_length
+
+let utf8_length s =
+  let rec length_aux s c i =
+    if i >= String.length s then c else
+    let n = Char.code (String.unsafe_get s i) in
+    let k =
+      if n < 0x80 then 1 else
+      if n < 0xe0 then 2 else
+      if n < 0xf0 then 3 else 4
+    in
+    length_aux s (c + 1) (i + k)
+  in
+  length_aux s 0 0
+
+let utf8string s =
+  fancystring s (utf8_length s)
+
+let utf8format f =
+  ksprintf utf8string f
+
+let char c =
+  assert (c <> '\n');
+  fancystring (String.make 1 c) 1
+
+let space =
+  char ' '
+
+let semicolon =
+  char ';'
+
+let hardline =
+  HardLine
+
+let blank n =
+  match n with
+  | 0 ->
+      empty
+  | 1 ->
+      space
+  | _ ->
+      Blank n
+
+let ifflat doc1 doc2 =
+  match doc1 with
+  | IfFlat (doc1, _)
+  | doc1 ->
+      IfFlat (doc1, doc2)
+
+let internal_break i =
+  ifflat (blank i) hardline
+
+let break0 =
+  internal_break 0
+
+let break1 =
+  internal_break 1
+
+let break i =
+  match i with
+  | 0 ->
+      break0
+  | 1 ->
+      break1
+  | _ ->
+      internal_break i
+
+let (^^) x y =
+  match x, y with
+  | Empty, _ ->
+      y
+  | _, Empty ->
+      x
+  | _, _ ->
+      Cat (requirement x ++ requirement y, x, y)
+
+let nest i x =
+  assert (i >= 0);
+  Nest (requirement x, i, x)
+
+let group x =
+  let req = requirement x in
+  if req = infinity then
+    x
+  else
+    Group (req, x)
+
+(* -------------------------------------------------------------------------- *)
+
+(* Printing blank space (indentation characters). *)
+
+let blank_length =
+  80
+
+let blank_buffer =
+  String.make blank_length ' '
+
+let rec blanks output n =
+  if n <= 0 then
+    ()
+  else if n <= blank_length then
+    Buffer.add_substring output blank_buffer 0 n
+  else begin
+    Buffer.add_substring output blank_buffer 0 blank_length;
+    blanks output (n - blank_length)
+  end
+
+(* -------------------------------------------------------------------------- *)
+
+(* The rendering engine maintains the following internal state. *)
+
+(* For simplicity, the ribbon width is considered equal to the line
+   width; in other words, there is no ribbon width constraint. *)
+
+(* For simplicity, the output channel is required to be an OCaml buffer.
+   It is stored within the [state] record. *)
+
+type state =
+  {
+    (* The line width. *)
+    width: int;
+    (* The current column. *)
+    mutable column: int;
+    (* The output buffer. *)
+    mutable output: Buffer.t;
+  }
+
+(* -------------------------------------------------------------------------- *)
+
+(* For simplicity, the rendering engine is *not* in tail-recursive style. *)
+
+let rec pretty state (indent : int) (flatten : bool) doc =
+  match doc with
+
+  | Empty ->
+      ()
+
+  | FancyString (s, ofs, len, apparent_length) ->
+      Buffer.add_substring state.output s ofs len;
+      state.column <- state.column + apparent_length
+
+  | Blank n ->
+      blanks state.output n;
+      state.column <- state.column + n
+
+  | HardLine ->
+      assert (not flatten);
+      Buffer.add_char state.output '\n';
+      blanks state.output indent;
+      state.column <- indent
+
+  | IfFlat (doc1, doc2) ->
+      pretty state indent flatten (if flatten then doc1 else doc2)
+
+  | Cat (_, doc1, doc2) ->
+      pretty state indent flatten doc1;
+      pretty state indent flatten doc2
+
+  | Nest (_, j, doc) ->
+      pretty state (indent + j) flatten doc
+
+  | Group (req, doc) ->
+      let flatten = flatten || state.column ++ req <== state.width in
+      pretty state indent flatten doc
+
+(* -------------------------------------------------------------------------- *)
+
+(* The engine's entry point. *)
+
+let pretty width doc =
+  let output = Buffer.create 512 in
+  let state = { width; column = 0; output } in
+  pretty state 0 false doc;
+  Buffer.contents output
+
+(* -------------------------------------------------------------------------- *)
+
+(* Additions to PPrintMini. *)
+
+let separate (sep : 'a) (xs : 'a list) : 'a list =
+  match xs with
+  | [] ->
+      []
+  | x :: xs ->
+      x :: List.flatten (List.map (fun x -> [sep; x]) xs)
+
+let concat (docs : document list) : document =
+  List.fold_right (^^) docs empty
+
+let comma =
+  utf8string "," ^^ break 1
+
+let commas docs =
+  concat (separate comma docs)
+
+let semi =
+  utf8string ";" ^^ break 1
+
+let semis docs =
+  concat (separate semi docs)
+
+let int i =
+  utf8format "%d" i
+
+let block doc =
+  nest 2 (break 0 ^^ doc) ^^ break 0
+
+let parens doc =
+  utf8string "(" ^^ block doc ^^ utf8string ")"
+
+let brackets doc =
+  utf8string "[" ^^ block doc ^^ utf8string "]"
+
+let ocaml_array_brackets doc =
+  utf8string "[| " ^^ block doc ^^ utf8string "|]"
+
+let tuple docs =
+  group (parens (commas docs))
+
+let list docs =
+  group (brackets (semis docs))
+
+let construct label docs =
+  match docs with
+  | [] ->
+      utf8string label
+  | _ ->
+      utf8string label ^^ space ^^ tuple docs
+
+let flow docs =
+  match docs with
+  | [] ->
+      []
+  | doc :: docs ->
+      doc :: map (fun doc -> group (break 1) ^^ doc) docs
+
+let raw_apply docs =
+  group (concat (flow docs))
+
+let apply f docs =
+  raw_apply (utf8string f :: docs)
+
+let parens_apply f docs =
+  parens (apply f docs)
+
+let piped_apply f docs =
+  (* Isolate the last argument. *)
+  assert (List.length docs > 0);
+  let docs = List.rev docs in
+  let doc, docs = List.hd docs, List.rev (List.tl docs) in
+  (* Print. *)
+  group (doc ^^ break 1 ^^ utf8string "|>" ^^ space ^^ apply f docs)
+
+let wrap (print : 'a -> document) : 'a -> string =
+  fun x -> pretty 70 (group (print x))
+
+(* -------------------------------------------------------------------------- *)
+
+(* An implementation of symbolic sequences. *)
+
+module SymSeq = struct
+
+  type _ seq =
+  | Empty    : 'a seq
+  | Singleton: 'a -> 'a seq
+  | Sum      : int * 'a seq * 'a seq -> 'a seq
+  | Product  : int * 'a seq * 'b seq -> ('a * 'b) seq
+  | Map      : int * ('a -> 'b) * 'a seq -> 'b seq
+
+  exception OutOfBounds
+
+  let length (type a) (s : a seq) : int =
+    match s with
+    | Empty ->
+        0
+    | Singleton _ ->
+        1
+    | Sum (length, _, _) ->
+        length
+    | Product (length, _, _) ->
+        length
+    | Map (length, _, _) ->
+        length
+
+  let is_empty s =
+    length s = 0
+
+  let empty =
+    Empty
+
+  let singleton x =
+    Singleton x
+
+  let sum s1 s2 =
+    if is_empty s1 then s2
+    else if is_empty s2 then s1
+    else Sum (length s1 + length s2, s1, s2)
+
+  let bigsum ss =
+    List.fold_left sum empty ss
+
+  let product s1 s2 =
+    if is_empty s1 || is_empty s2 then
+      empty
+    else
+      Product (length s1 * length s2, s1, s2)
+
+  let map phi s =
+    if is_empty s then
+      empty
+    else
+      Map (length s, phi, s)
+
+  let rec get : type a . a seq -> int -> a =
+    fun s i ->
+      match s with
+      | Empty ->
+          raise OutOfBounds
+      | Singleton x ->
+          if i = 0 then x else raise OutOfBounds
+      | Sum (_, s1, s2) ->
+          let n1 = length s1 in
+          if i < n1 then get s1 i
+          else get s2 (i - n1)
+      | Product (_, s1, s2) ->
+          let q, r = i / length s2, i mod length s2 in
+          get s1 q, get s2 r
+      | Map (_, phi, s) ->
+          phi (get s i)
+
+  let rec foreach : type a . a seq -> (a -> unit) -> unit =
+    fun s k ->
+      match s with
+      | Empty ->
+          ()
+      | Singleton x ->
+          k x
+      | Sum (_, s1, s2) ->
+          foreach s1 k;
+          foreach s2 k
+      | Product (_, s1, s2) ->
+          foreach s1 (fun x1 ->
+            foreach s2 (fun x2 ->
+              k (x1, x2)
+            )
+          )
+      | Map (_, phi, s) ->
+          foreach s (fun x -> k (phi x))
+
+  let elements (s : 'a seq) : 'a list =
+    let xs = ref [] in
+    foreach s (fun x -> xs := x :: !xs);
+    List.rev !xs
+
+  (* Extract a list of at most [threshold] elements from the sequence [s]. *)
+
+  let sample threshold (s : 'a seq) : 'a list =
+    if length s <= threshold then
+      (* If the sequence is short enough, keep of all its elements. *)
+      elements s
+    else
+      (* Otherwise, keep a randomly chosen sample. *)
+      let xs = ref [] in
+      for i = 1 to threshold do
+        let i = Random.int (length s) in
+        let x = get s i in
+        xs := x :: !xs
+      done;
+      !xs
+
+end
+
+type 'a seq =
+  'a SymSeq.seq
+
+(* -------------------------------------------------------------------------- *)
+
+(* A fixed point combinator. *)
+
+let fix : type a b . ((a -> b) -> (a -> b)) -> (a -> b) =
+  fun ff ->
+    let table = Hashtbl.create 128 in
+    let rec f (x : a) : b =
+      try
+        Hashtbl.find table x
+      with Not_found ->
+        let y = ff f x in
+        Hashtbl.add table x y;
+        y
+    in
+    f
+
+let   curry f x y = f (x, y)
+let uncurry f (x, y) = f x y
+
+let fix2 : type a b c . ((a -> b -> c) -> (a -> b -> c)) -> (a -> b -> c) =
+  fun ff ->
+    let ff f = uncurry (ff (curry f)) in
+    curry (fix ff)
+
+(* -------------------------------------------------------------------------- *)
+
+(* MiniFeat. *)
+
+module Feat = struct
+
+  (* Core combinators. *)
+
+  type 'a enum =
+    int -> 'a SymSeq.seq
+
+  let empty : 'a enum =
+    fun _s ->
+      SymSeq.empty
+
+  let zero =
+    empty
+
+  let enum (xs : 'a SymSeq.seq) : 'a enum =
+    fun s ->
+      if s = 0 then xs else SymSeq.empty
+
+  let just (x : 'a) : 'a enum =
+    (* enum (SymSeq.singleton x) *)
+    fun s ->
+      if s = 0 then SymSeq.singleton x else SymSeq.empty
+
+  let pay (enum : 'a enum) : 'a enum =
+    fun s ->
+      if s = 0 then SymSeq.empty else enum (s-1)
+
+  let sum (enum1 : 'a enum) (enum2 : 'a enum) : 'a enum =
+    fun s ->
+      SymSeq.sum (enum1 s) (enum2 s)
+
+  let ( ++ ) =
+    sum
+
+  let rec _up i j =
+    if i <= j then
+      i :: _up (i + 1) j
+    else
+      []
+
+  let product (enum1 : 'a enum) (enum2 : 'b enum) : ('a * 'b) enum =
+    fun s ->
+      SymSeq.bigsum (
+        List.map (fun s1 ->
+          let s2 = s - s1 in
+          SymSeq.product (enum1 s1) (enum2 s2)
+        ) (_up 0 s)
+      )
+
+  let ( ** ) =
+    product
+
+  let balanced_product (enum1 : 'a enum) (enum2 : 'b enum) : ('a * 'b) enum =
+    fun s ->
+      if s mod 2 = 0 then
+        let s = s / 2 in
+        SymSeq.product (enum1 s) (enum2 s)
+      else
+        let s = s / 2 in
+        SymSeq.sum
+          (SymSeq.product (enum1 s) (enum2 (s+1)))
+          (SymSeq.product (enum1 (s+1)) (enum2 s))
+
+  let ( *-* ) =
+    balanced_product
+
+  let map (phi : 'a -> 'b) (enum : 'a enum) : 'b enum =
+    fun s ->
+      SymSeq.map phi (enum s)
+
+  (* Convenience functions. *)
+
+  let finite (xs : 'a list) : 'a enum =
+    List.fold_left (++) zero (List.map just xs)
+
+  let bool : bool enum =
+    just false ++ just true
+
+  let list (elem : 'a enum) : 'a list enum =
+    let cons (x, xs) = x :: xs in
+    fix (fun list ->
+      just [] ++ pay (map cons (elem ** list))
+    )
+
+  (* Extract a list of at most [threshold] elements of each size,
+     for every size up to [s] (included), from the enumeration [e]. *)
+
+  let sample threshold s (e : 'a enum) : 'a list =
+    List.flatten (
+      List.map (fun i ->
+        SymSeq.sample threshold (e i)
+      ) (_up 0 s)
+    )
+
+end
+
+type 'a enum =
+  'a Feat.enum
+
+(* -------------------------------------------------------------------------- *)
+
+(* Generic testing utilities. *)
+
+(* When we fail, the exception carries a learn-ocaml report. *)
+
+exception Fail of report
+
+(* [section title report] encloses the report [report] within a section
+   entitled [title], producing a larger report. *)
+
+let section title report : report =
+  [R.Section ([R.Text title], report)]
+
+(* This generic function takes as an argument the text of the message that
+   will be displayed. A message is a list of inline things. *)
+
+let fail (text : R.inline list) =
+  let report = [R.Message (text, R.Failure)] in
+  raise (Fail report)
+
+(* This is a special case where the message is a singleton list containing
+   a single string. The string can be formatted using a printf format. *)
+
+let fail_text format =
+  Printf.ksprintf (fun s -> fail [R.Text s]) format
+
+(* [protect f] evaluates [f()], which either returns normally and produces a
+   report, or raises [Fail] and produces a report. In either case, the report
+   is returned. *)
+
+(* If an unexpected exception is raised, in student code or in grading code,
+   the exception is displayed as part of a failure report. (Ideally, grading
+   code should never raise an exception!) It is debatable whether one should
+   show just the name of the exception, or a full backtrace; I choose the
+   latter, on the basis that more information is always preferable. *)
+
+let protect f =
+  try
+    T.run_timeout f
+  with
+  | Fail report ->
+      report
+  | TODO ->
+      let text = [
+        R.Text "Not yet implemented."
+      ] in
+      let report = [R.Message (text, R.Failure)] in
+      report
+  | (e : exn) ->
+      let text = [
+        R.Text "The following exception is raised and never caught:";
+        R.Break;
+        R.Output (Printexc.to_string e);
+        R.Output (Printexc.get_backtrace());
+      ] in
+      let report = [R.Message (text, R.Failure)] in
+      report
+
+(* [successful] tests whether a report is successful. *)
+
+let successful_status = function
+  | R.Success _
+  | R.Warning
+  | R.Informative
+  | R.Important ->
+     true
+  | R.Failure ->
+     false
+
+let rec successful_item = function
+  | R.Section (_, r) ->
+      successful r
+  | R.Message (_, status) ->
+      successful_status status
+
+and successful (r : report) =
+  List.for_all successful_item r
+
+let (-@>) (r : report) (f : unit -> report) : report =
+  if successful r then
+    r @ f()
+  else
+    r
+
+(* -------------------------------------------------------------------------- *)
+
+(* Generic test functions. *)
+
+let grab ty name k =
+  T.test_value (T.lookup_student ty name) k
+
+let test_value_0 name ty reference eq =
+  grab ty name (fun candidate ->
+    protect (fun () ->
+      if not (eq candidate reference) then
+        fail [
+          R.Code name; R.Text "is incorrect.";
+        ];
+      let message = [ R.Code name; R.Text "is correct."; ] in
+      [ R.Message (message, R.Success 1) ]
+    )
+  )
+
+let correct name =
+  let message = [ R.Code name; R.Text "seems correct."; ] in
+  [ R.Message (message, R.Success 1) ]
+
+(* When doing black-box testing of a complete module, we are not testing just
+   one function in isolation, but a group of functions together. In that case,
+   the wording of the error message is somewhat different. Instead of saying
+   that a specific function is incorrect, we want to say that an expression
+   [expr] yields an incorrect result. *)
+
+let eq_behavior eq_value actual_behavior expected_behavior =
+  match actual_behavior, expected_behavior with
+  | Ok actual, Ok expected ->
+      eq_value actual expected (* value comparison *)
+  | Error actual, Error expected ->
+      actual = expected  (* exception comparison *)
+  | Ok _, Error _
+  | Error _, Ok _ ->
+      false
+
+let show_actual_behavior show_value behavior =
+  match behavior with
+  | Ok v ->
+      R.Text "produces the following result:" ::
+      R.Output (show_value v) ::
+      []
+  | Error e ->
+      R.Text "raises the following exception:" ::
+      R.Output (Printexc.to_string e) ::
+      []
+
+let show_expected_behavior show_value behavior =
+  match behavior with
+  | Ok v ->
+      R.Text "This is invalid. Producing the following result is valid:" ::
+      R.Output (show_value v) ::
+      []
+  | Error e ->
+      R.Text "This is invalid. Raising the following exception is valid:" ::
+      R.Output (Printexc.to_string e) ::
+      []
+
+let something_is_wrong =
+  R.Text "Something is wrong." ::
+  []
+
+let incorrect name =
+  R.Code name :: R.Text "is incorrect." ::
+  R.Break ::
+  []
+
+let black_box_compare
+  (* Value equality and display, used to compare and show results. *)
+  eq_value show_value
+  (* The beginning of the error message. Use [something_is_wrong] or [incorrect name]. *)
+  announcement
+  (* Expression display. *)
+  show_expr expr
+  (* Actual behavior and expected behavior. *)
+  actual_behavior
+  expected_behavior
+=
+  (* Allow [TODO] to escape and abort the whole test. *)
+  if actual_behavior = Error TODO then
+    raise TODO
+  else if not (eq_behavior eq_value actual_behavior expected_behavior) then
+    fail (
+      announcement @
+      R.Text "The following expression:" ::
+      R.Break ::
+      R.Code (show_expr expr) ::
+      R.Break ::
+      show_actual_behavior show_value actual_behavior @
+      show_expected_behavior show_value expected_behavior
+    )
+
+let test_value_1 name ty reference printx showy eqy tests =
+  grab ty name (fun candidate ->
+    protect (fun () ->
+      tests |> List.iter (fun x ->
+        let actual_behavior = T.result (fun () -> candidate x)
+        and expected_behavior = T.result (fun () -> reference x) in
+        let print_expr () =
+          apply name [ printx x ]
+            (* beware: [printx] must produce parentheses if necessary *)
+        in
+        black_box_compare
+          eqy showy
+          (incorrect name)
+          (wrap print_expr) ()
+          actual_behavior
+          expected_behavior
+      );
+      correct name
+    )
+  )
+
+let test_value_2 name ty reference printx1 printx2 showy eqy tests =
+  grab ty name (fun candidate ->
+    protect (fun () ->
+      tests |> List.iter (fun ((x1, x2) as x) ->
+        let actual_behavior = T.result (fun () -> candidate x1 x2)
+        and expected_behavior = T.result (fun () -> reference x1 x2) in
+        let print_expr () =
+          apply name [ printx1 x1; printx2 x2 ]
+            (* beware: [printx1] and [printx2] must produce parentheses
+               if necessary *)
+        in
+        black_box_compare
+          eqy showy
+          (incorrect name)
+          (wrap print_expr) ()
+          actual_behavior
+          expected_behavior
+      );
+      correct name
+    )
+  )
+
+let test_value_3 name ty reference printx1 printx2 printx3 showy eqy tests =
+  grab ty name (fun candidate ->
+    protect (fun () ->
+      tests |> List.iter (fun ((x1, x2, x3) as x) ->
+        let actual_behavior = T.result (fun () -> candidate x1 x2 x3)
+        and expected_behavior = T.result (fun () -> reference x1 x2 x3) in
+        let print_expr () =
+          apply name [ printx1 x1; printx2 x2; printx3 x3 ]
+            (* beware: [printx1], etc. must produce parentheses
+               if necessary *)
+        in
+        black_box_compare
+          eqy showy
+          (incorrect name)
+          (wrap print_expr) ()
+          actual_behavior
+          expected_behavior
+      );
+      correct name
+    )
+  )
+
+(* -------------------------------------------------------------------------- *)
+
+(* List-based enumerations. *)
+
+let flat_map f xss =
+  List.flatten (List.map f xss)
+
+(* [up i j] is the list of the integers of [i] included up to [j] excluded. *)
+
+(* [upk i j k] is [up i j @ k]. *)
+
+let rec upk i j k =
+  if i < j then
+    i :: upk (i + 1) j k
+  else
+    k
+
+let up i j =
+  upk i j []
+
+(* [pairs xs ys] is the list of all pairs [x, y] where [x] is drawn from [xs]
+   and [y] is drawn from [ys]. In other words, it is the Cartesian product of
+   the lists [xs] and [ys]. *)
+
+let pairs xs ys =
+  xs |> flat_map (fun x ->
+    ys |> flat_map (fun y ->
+      [x, y]
+    )
+  )
+
+(* [split n f] enumerates all manners of splitting [n] into [n1 + n2], where
+   [n1] and [n2] can be zero. For each such split, the enumeration [f n1 n2]
+   is produced. *)
+
+let split n f =
+  flat_map (fun n1 ->
+    let n2 = n - n1 in
+    f n1 n2
+  ) (up 0 (n+1))
+
+(* If [f i] is an enumeration, then [deepening f n] is the concatenation
+   of the enumerations [f 0, f 1, ... f n]. *)
+
+let deepening (f : int -> 'a list) (n : int) : 'a list =
+  flat_map f (up 0 (n+1))
+
+(* -------------------------------------------------------------------------- *)
+
+(* Printers. *)
+
+(* A printer for strings. *)
+
+let show_string s =
+  sprintf "\"%s\"" (String.escaped s)
+
+let print_string s =
+  utf8string (show_string s)
+
+(* A printer for integers. *)
+
+let print_int =
+  int
+
+let show_int i =
+  sprintf "%d" i
+
+(* A printer for characters. *)
+
+let show_char c =
+  sprintf "'%s'" (Char.escaped c)
+
+(* A printer for Booleans. *)
+
+let show_bool b =
+  if b then "true" else "false"
+
+let print_bool b =
+  utf8string (show_bool b)
+
+(* A printer for options. *)
+
+let print_option print = function
+  | None ->
+       utf8string "None"
+  | Some x ->
+       construct "Some" [ print x ]
+
+(* A printer for arrays. *)
+
+let print_array print_element a =
+  group (ocaml_array_brackets (concat (
+    a |> Array.map (fun x ->
+      print_element x ^^ semicolon ^^ break 1
+    ) |> Array.to_list
+  )))
+
+(* A printer for lists. *)
+
+let print_list print_element xs =
+  list (map print_element xs)
+
+let print_list_int =
+  print_list print_int
+
+let show_list_int =
+  wrap print_list_int
+
+let print_int_int (x, t) =
+  parens (
+    utf8format "(* value: *) %d, (* work: *) %d" x t
+  )
+
+let print_list_int_int =
+  print_list print_int_int
+
+let show_list_int_int =
+  wrap print_list_int_int
+
+(* -------------------------------------------------------------------------- *)
+
+(* A DSL for monadic computations. *)
+
+(* The syntax of pure expressions allows zero-ary operators (constants) of
+   type [int] and unary operators of type ['a -> bool] and binary operators of
+   type ['a -> 'a -> 'a]. Each operator is accompanied with its textual
+   appearance as a plain OCaml expression. *)
+
+(* In the type [('g, 'a) expr], ['g] is the type of every variable in scope,
+   and ['a] is the type of the expression. *)
+
+(* In the syntax of computations, we restrict the type of [CBind] so that
+   every intermediate computation has result type ['a] and (therefore) every
+   variable in scope has type ['a] as well. This removes the need for dealing
+   with heterogeneous environments (both at the type level and value level),
+   facilitates printing of computations, etc. *)
+
+(* We ask the student to implement [at_most_once] rather than [once] because
+   the former has a simpler type, which fits the restriction above. *)
+
+type (_, _) expr =
+  | EVar: int (* de Bruijn index *) -> ('g, 'g) expr
+  | EConst: int -> ('g, int) expr
+
+type fair =
+  bool
+    (* The fair variant of [choose] is [interleave]. *)
+    (* The fair variant of [>>=] is [>>-]. *)
+
+type 'a comp =
+  (* Combinators implemented by me. *)
+  | CDelay of 'a comp
+  | CTick of 'a comp
+  (* Core combinators. (Unfair variants.) (Question 1.) *)
+  | CRet of ('a, 'a) expr
+  | CBind of fair * 'a comp * 'a comp (* >>= *)
+  | CFail
+  | CChoose of fair * 'a comp * 'a comp
+  (* More combinators. (Fair variants.) (Questions 2-4.) *)
+  | CAtMostOnce of 'a comp
+
+(* Generators. *)
+
+module DSLGen = struct
+
+  open Feat
+
+  (* Integer expressions. *)
+
+  (* [n] is the number of variables in scope. Memoization takes place over the
+     pair [(n, s)], where [s] is the size parameter, which remains implicit. *)
+
+  let evar x = EVar x
+  let econst k = EConst k
+
+  let int_expr : int -> (int, int) expr enum =
+    fix2 (fun int_expr n ->
+      map evar (finite (up 0 n)) ++
+      map econst (finite [ 0; 1 ])
+    )
+
+  (* Commands. *)
+
+  let cret e = CRet e
+  let cbind (c1, c2) = CBind (false, c1, c2)
+  let cdelay c = CDelay c
+  let ctick c = CTick c
+  let cchoose (c1, c2) = CChoose (false, c1, c2)
+  let catmostonce c = CAtMostOnce c
+  let cfairbind (c1, c2) = CBind (true, c1, c2)
+  let cfairchoose (c1, c2) = CChoose (true, c1, c2)
+
+  let core comp n =
+    map cret (int_expr n) ++
+    just CFail ++
+    pay (
+      map cbind (comp n ** comp (n+1)) ++
+      map cdelay (comp n) ++
+      map cchoose (comp n ** comp n)
+    )
+
+  (* Depending on the question number (Question 1, 2, etc.) we use more
+     and more combinators. *)
+
+  let q1 : int -> int comp enum =
+    fix2 (fun comp n ->
+      core comp n
+    )
+
+  let q2 : int -> int comp enum =
+    fix2 (fun comp n ->
+      core comp n ++
+      pay (map catmostonce (comp n))
+    )
+
+  let q3 : int -> int comp enum =
+    fix2 (fun comp n ->
+      core comp n ++
+      pay (map catmostonce (comp n)) ++
+      pay (map cfairchoose (comp n ** comp n))
+    )
+
+  let q4 : int -> int comp enum =
+    fix2 (fun comp n ->
+      core comp n ++
+      pay (map catmostonce (comp n)) ++
+      pay (map cfairchoose (comp n ** comp n)) ++
+      pay (map cfairbind (comp n ** comp n))
+    )
+
+end
+
+(* Instrumenting a command with [tick] instructions. *)
+
+(* We could insert [tick]s everywhere, but our counter-examples are a
+   little more readable if we insert fewer ticks. *)
+
+let rec instrument c =
+  match c with
+  | CRet _
+  | CFail ->
+      (* Tick [return] and [fail]. *)
+      CTick c
+  | CBind (fair, c1, c2) ->
+      (* Do not tick [bind]. *)
+      CBind (fair, instrument c1, instrument c2)
+  | CDelay c ->
+      (* Do not tick [delay]. *)
+      CDelay (instrument c)
+  | CTick c ->
+      (* won't happen *)
+      assert false
+  | CChoose (fair, c1, c2) ->
+      (* Do not tick [choose]. *)
+      CChoose (fair, instrument c1, instrument c2)
+  | CAtMostOnce c ->
+      (* Do not tick [at_most_once]. *)
+      CAtMostOnce (instrument c)
+
+(* Printers. *)
+
+module DSLPrinter = struct
+
+  type senv =
+    int
+
+  let show_var senv x =
+    assert (0 <= x && x < senv);
+    (* Convert the de Bruijn index [x] to a de Bruijn level. *)
+    let x = senv - 1 - x in
+    (* Use a fixed conversion scheme. *)
+    assert (x < 26);
+    let c = Char.chr (Char.code 'a' + x) in
+    String.make 1 c
+
+  let print_var senv x =
+    utf8string (show_var senv x)
+
+  let rec print_atomic_expr : type g a . senv -> (g, a) expr -> document =
+    fun senv e ->
+      match e with
+      | EVar x ->
+          print_var senv x
+      | EConst k ->
+          print_int k
+      | _ ->
+          parens (print_expr senv e)
+
+  and print_expr : type g a . senv -> (g, a) expr -> document =
+    fun senv e ->
+      match e with
+      | EVar _ ->
+          print_atomic_expr senv e
+      | EConst _ ->
+          print_atomic_expr senv e
+
+  let rec print_atomic_comp senv c =
+    match c with
+    | CFail ->
+        utf8string "fail"
+    | _ ->
+        parens (print_comp senv c)
+
+  and print_tight_comp senv c =
+    match c with
+    | CFail ->
+        print_atomic_comp senv c
+    | CRet e ->
+        apply "return" [ print_atomic_expr senv e ]
+    | CDelay c ->
+        apply "delay" [ print_atomic_comp senv c ]
+    | CTick c ->
+        apply "tick" [ print_atomic_comp senv c ]
+    | CAtMostOnce c ->
+        apply "at_most_once" [ print_atomic_comp senv c ]
+    | CChoose (fair, c1, c2) ->
+        apply
+          (if fair then "interleave" else "choose")
+          [ print_atomic_comp senv c1; print_atomic_comp senv c2 ]
+    | _ ->
+        parens (print_comp senv c)
+
+  and print_comp senv c =
+    group begin match c with
+    | CBind (fair, c1, c2) ->
+        let op = if fair then ">>-" else ">>=" in
+        group (
+          print_tight_comp senv c1 ^^ break 1 ^^
+          utf8format "%s fun %s ->" op (show_var (senv+1) 0)
+        ) ^^ break 1 ^^
+        print_tight_comp (senv+1) c2
+    | _ ->
+        print_tight_comp senv c
+    end
+
+  let print_atomic_comp c =
+    print_atomic_comp 0 c
+
+  let to_list doc =
+    piped_apply "Seq.to_list" [ doc ]
+
+  let take depth doc =
+    piped_apply "Seq.take" [ print_int depth; doc ]
+
+  let sols doc =
+    apply "sols" [ doc ]
+
+  let snapshot doc =
+    apply "Seq.map" [ utf8string "snapshot"; doc ]
+
+  let print_comp_sols_take depth c =
+    to_list (take depth (sols (print_atomic_comp c)))
+
+  let show_comp_sols_take depth =
+    wrap (print_comp_sols_take depth)
+
+  let print_comp_sols_snapshot_take depth c =
+    to_list (take depth (snapshot (sols (print_atomic_comp c))))
+
+  let show_comp_sols_snapshot_take depth =
+    wrap (print_comp_sols_snapshot_take depth)
+
+end
+
+(* A DSL interpreter. *)
+
+(* An expression evaluator. *)
+
+(* This evaluator is parameterized over an implementation of the signature
+   [REQUIRED]. *)
+
+(* Because (I think) we can only grab the student's code at a monomorphic
+   type, we cannot require these functions to be polymorphic. We require
+   just the monomorphic instances that we need for our test. *)
+
+type mono =
+  int
+
+module type REQUIRED = sig
+  val return: mono -> mono m
+  val (>>=) : mono m -> (mono -> mono m) -> mono m
+  val fail: mono m
+  val choose: mono m -> mono m -> mono m
+  (* The following components are optional, as they appear in
+     Questions 2-4. *)
+  val at_most_once: (mono m -> mono m) option
+  val interleave: (mono m -> mono m -> mono m) option
+  val (>>-): (mono m -> (mono -> mono m) -> mono m) option
+end
+
+module S = struct
+  include Solution
+  let at_most_once = Some at_most_once
+  let interleave = Some interleave
+  let (>>-) = Some (>>-)
+end
+
+let solution =
+  (module S : REQUIRED)
+
+let project o =
+  match o with
+  | Some x -> x
+  | None   -> assert false
+
+module DSLInterpreter = struct
+
+  let rec eval_expr : type g a . g list -> (g, a) expr -> a =
+    fun env e ->
+      match e with
+      | EVar x ->
+          List.nth env x
+      | EConst k ->
+          k
+
+  let eval_comp required (env : mono list) (c : mono comp) : mono m =
+    let module R = (val required : REQUIRED) in
+    let open R in
+    let rec eval_comp env c =
+      match c with
+      | CRet e ->
+          return (eval_expr env e)
+      | CBind (fair, c1, c2) ->
+          let bind = if fair then project (>>-) else (>>=) in
+          bind
+            (eval_comp env c1)
+            (fun x1 -> eval_comp (x1 :: env) c2)
+      | CDelay c ->
+          delay (fun () -> eval_comp env c)
+      | CTick c ->
+          tick (eval_comp env c)
+      | CFail ->
+          fail
+      | CChoose (fair, c1, c2) ->
+          let plus = if fair then project interleave else choose in
+          plus (eval_comp env c1) (eval_comp env c2)
+      | CAtMostOnce c ->
+          let at_most_once = project at_most_once in
+          at_most_once (eval_comp env c)
+    in
+    eval_comp env c
+
+  let eval_comp required (c : mono comp) : mono m =
+    eval_comp required [] c
+
+end
+
+(* -------------------------------------------------------------------------- *)
+
+(* Our black-box grading machinery. *)
+
+(* In Question 1, we grade four construction functions: [return], [>>=],
+   [fail], [choose], observed through one observation function, [sols].
+   In Questions 2-4, we gradually add three more construction functions,
+   [at_most_once], [interleave], and [>>-]. The testing machinery is the
+   same. *)
+
+module P = DSLPrinter
+module I = DSLInterpreter
+
+(* In order to avoid trouble with infinite sequences, we compare and print
+   sequences only down to a certain [depth]. *)
+
+let depth =
+  20
+
+(* First, we test functional correctness. We generate a computation using the
+   constructor functions, and apply [sols] to it, yielding a sequence. We
+   truncate this sequence at depth [depth] and force its evaluation by turning
+   it into a list. Then, we check that this list of results is correct by
+   comparing against our solution. *)
+
+let test_correctness tests student sols =
+  tests |> List.iter (fun (c : mono comp) ->
+    let expected_behavior =
+      Ok (
+        I.eval_comp solution c
+        |> Solution.sols
+        |> Seq.take depth
+        |> Seq.to_list
+      )
+    in
+    let actual_behavior =
+      T.result (fun () ->
+        I.eval_comp student c
+        |> sols
+        |> Seq.take depth
+        |> Seq.to_list
+      )
+    in
+    black_box_compare
+      (=) show_list_int
+      something_is_wrong
+      (P.show_comp_sols_take depth) c
+      actual_behavior
+      expected_behavior
+  );
+  (* Success. *)
+  let points = 1 in
+  let msg =
+    sprintf "The code seems correct. Tested %d scenarios."
+      (List.length tests)
+  in
+  [ R.success points msg ]
+
+(* Second, we test that computations are performed on demand, that is, as late
+   as possible. That is, demanding the next result should force execution to
+   take place only as far as necessary in order to produce this result. To
+   check this, we instrument our test computations with [tick] instructions,
+   which increment the global counter [time], and decorate every result with
+   the time at which it is produced. (A call to [Seq.map snapshot] suffices
+   for this purpose.) We check that these times are correct by comparing
+   against our solution. *)
+
+let test_laziness tests student sols =
+  let tests = List.map instrument tests in
+  tests |> List.iter (fun (c : mono comp) ->
+    let expected_behavior =
+      Ok (
+        reset();
+        I.eval_comp solution c
+        |> Solution.sols
+        |> Seq.map snapshot
+        |> Seq.take depth |> Seq.to_list
+      )
+    in
+    let actual_behavior =
+      T.result (fun () ->
+        reset();
+        I.eval_comp student c
+        |> sols
+        |> Seq.map snapshot
+        |> Seq.take depth |> Seq.to_list
+      )
+    in
+    black_box_compare
+      (=) show_list_int_int
+      [ R.Text "Some computations take place too early." ]
+      (P.show_comp_sols_snapshot_take depth) c
+      actual_behavior
+      expected_behavior
+  );
+  (* Success. *)
+  let points = 1 in
+  let msg = "The code seems lazy." in
+  [ R.success points msg ]
+
+(* Combine the above two phases. *)
+
+let test_both tests student sols =
+  section "Functional correctness" (
+    protect (fun () ->
+      test_correctness tests student sols
+    )
+  ) -@> fun () ->
+  section "Laziness" (
+    protect (fun () ->
+      test_laziness tests student sols
+    )
+  )
+
+(* -------------------------------------------------------------------------- *)
+
+(* Question 1. *)
+
+(* Grading the core functions: [return], [>>=], [fail], [choose], [sols]. *)
+
+let grab_core k =
+  (* Grab the student's five basic functions. *)
+  grab [%ty: mono -> mono m] "return" (fun return ->
+  grab [%ty: mono m -> (mono -> mono m) -> mono m] ">>=" (fun (>>=) ->
+  grab [%ty: mono m] "fail" (fun fail ->
+  grab [%ty: mono m -> mono m -> mono m] "choose" (fun choose ->
+  grab [%ty: mono m -> mono Seq.t] "sols" (fun sols ->
+  let module S = struct
+    let return = return
+    let (>>=) = (>>=)
+    let fail = fail
+    let choose = choose
+    let at_most_once = None
+    let interleave = None
+    let (>>-) = None
+  end in
+  let student = (module S : REQUIRED) in
+  k student sols
+  )))))
+
+let test_core () =
+  section "Question 1" (
+    grab_core (fun student sols ->
+      (* Generate test cases. *)
+      let tests = Feat.sample 1000 4 (DSLGen.q1 0) in
+      (* Test. *)
+      test_both tests student sols
+    )
+  )
+
+(* -------------------------------------------------------------------------- *)
+
+(* Question 2. *)
+
+(* Grading [at_most_once]. *)
+
+let grab_at_most_once k =
+  grab_core (fun student sols ->
+  grab [%ty: mono m -> mono m] "at_most_once" (fun candidate ->
+  let module S = struct
+    include (val student : REQUIRED)
+    let at_most_once = Some candidate
+  end in
+  let student = (module S : REQUIRED) in
+  k student sols
+  ))
+
+let test_at_most_once () =
+  section "Question 2" (
+    grab_at_most_once (fun student sols ->
+      (* Generate test cases. *)
+      let tests = Feat.sample 1000 4 (DSLGen.q2 0) in
+      (* Test. *)
+      test_both tests student sols
+    )
+  )
+
+(* -------------------------------------------------------------------------- *)
+
+(* Question 3. *)
+
+(* Grading [interleave]. *)
+
+let grab_interleave k =
+  grab_at_most_once (fun student sols ->
+  grab [%ty: mono m -> mono m -> mono m] "interleave" (fun candidate ->
+  let module S = struct
+    include (val student : REQUIRED)
+    let interleave = Some candidate
+  end in
+  let student = (module S : REQUIRED) in
+  k student sols
+  ))
+
+let test_interleave () =
+  section "Question 3" (
+    grab_interleave (fun student sols ->
+      (* Generate test cases. *)
+      let tests = Feat.sample 1000 4 (DSLGen.q3 0) in
+      (* Test. *)
+      test_both tests student sols
+    )
+  )
+
+(* -------------------------------------------------------------------------- *)
+
+(* Question 4. *)
+
+(* Grading [>>-]. *)
+
+let grab_fair_bind k =
+  grab_interleave (fun student sols ->
+  grab [%ty: mono m -> (mono -> mono m) -> mono m] ">>-" (fun candidate ->
+  let module S = struct
+    include (val student : REQUIRED)
+    let (>>-) = Some candidate
+  end in
+  let student = (module S : REQUIRED) in
+  k student sols
+  ))
+
+let test_fair_bind () =
+  section "Question 4" (
+    grab_fair_bind (fun student sols ->
+      (* Generate test cases. *)
+      let tests = Feat.sample 3000 5 (DSLGen.q4 0) in
+      (* Test. *)
+      test_both tests student sols
+    )
+  )
+
+(* -------------------------------------------------------------------------- *)
+
+(* Main. *)
+
+let report () =
+  test_core() -@>
+  test_at_most_once -@>
+  test_interleave -@>
+  test_fair_bind -@>
+  fun () -> []
+
+let () =
+  T.set_result (T.ast_sanity_check code_ast report)

--- a/exercises/nondet_monad_seq/wrong/at_most_once_id.log
+++ b/exercises/nondet_monad_seq/wrong/at_most_once_id.log
@@ -1,0 +1,2 @@
+Learnocaml v.0.10 running.
+[ Loading the prelude. ][K[ Preparing the test environment. ][K[ Loading your code. ][K[ Loading the solution. ][K[ Preparing to launch the tests. ][K[ Launching the test bench. ][K.                              - Failure - 2 points

--- a/exercises/nondet_monad_seq/wrong/at_most_once_id.ml
+++ b/exercises/nondet_monad_seq/wrong/at_most_once_id.ml
@@ -1,0 +1,18 @@
+let return (x : 'a) : 'a m =
+  Seq.singleton x
+
+let (>>=) (m1 : 'a m) (f2 : 'a -> 'b m) : 'b m =
+  m1 |> Seq.map f2 |> Seq.flatten
+
+let fail : 'a m =
+  Seq.nil
+
+let choose (m1 : 'a m) (m2 : 'a m) : 'a m =
+  Seq.concat m1 m2
+
+let sols (m : 'a m) : 'a Seq.t =
+  m
+
+let at_most_once (m : 'a m) : 'a m =
+  (* Basic attempt to cheat! *)
+  m

--- a/exercises/nondet_monad_seq/wrong/at_most_once_id.report.txt
+++ b/exercises/nondet_monad_seq/wrong/at_most_once_id.report.txt
@@ -1,0 +1,24 @@
+Question 1
+  Found [return] with compatible type.
+  Found [>>=] with compatible type.
+  Found [fail] with compatible type.
+  Found [choose] with compatible type.
+  Found [sols] with compatible type.
+  Functional correctness
+    Success 1: The code seems correct. Tested 2411 scenarios.
+  Laziness
+    Success 1: The code seems lazy.
+Question 2
+  Found [return] with compatible type.
+  Found [>>=] with compatible type.
+  Found [fail] with compatible type.
+  Found [choose] with compatible type.
+  Found [sols] with compatible type.
+  Found [at_most_once] with compatible type.
+  Functional correctness
+    Failure: Something is wrong. The following expression:
+      
+       | sols (at_most_once (choose (return 0) (return 0))) |> Seq.take 20
+       | |> Seq.to_list
+      produces the following result: [[0; 0]] This is invalid. Producing the
+      following result is valid: [[0]]

--- a/exercises/nondet_monad_seq/wrong/bind_fail.log
+++ b/exercises/nondet_monad_seq/wrong/bind_fail.log
@@ -1,0 +1,2 @@
+Learnocaml v.0.10 running.
+[ Loading the prelude. ][K[ Preparing the test environment. ][K[ Loading your code. ][K[ Loading the solution. ][K[ Preparing to launch the tests. ][K[ Launching the test bench. ][K.                              - Failure - 0 points

--- a/exercises/nondet_monad_seq/wrong/bind_fail.ml
+++ b/exercises/nondet_monad_seq/wrong/bind_fail.ml
@@ -1,0 +1,14 @@
+let return (x : 'a) : 'a m =
+  Seq.singleton x
+
+let (>>=) (m1 : 'a m) (f2 : 'a -> 'b m) : 'b m =
+  Seq.nil (* wrong *)
+
+let fail : 'a m =
+  Seq.nil
+
+let choose (m1 : 'a m) (m2 : 'a m) : 'a m =
+  Seq.concat m1 m2
+
+let sols (m : 'a m) : 'a Seq.t =
+  m

--- a/exercises/nondet_monad_seq/wrong/bind_fail.report.txt
+++ b/exercises/nondet_monad_seq/wrong/bind_fail.report.txt
@@ -1,0 +1,12 @@
+Question 1
+  Found [return] with compatible type.
+  Found [>>=] with compatible type.
+  Found [fail] with compatible type.
+  Found [choose] with compatible type.
+  Found [sols] with compatible type.
+  Functional correctness
+    Failure: Something is wrong. The following expression:
+      
+       | sols (return 0 >>= fun a -> return a) |> Seq.take 20 |> Seq.to_list
+      produces the following result: [[]] This is invalid. Producing the
+      following result is valid: [[0]]

--- a/exercises/nondet_monad_seq/wrong/bind_once.log
+++ b/exercises/nondet_monad_seq/wrong/bind_once.log
@@ -1,0 +1,2 @@
+Learnocaml v.0.10 running.
+[ Loading the prelude. ][K[ Preparing the test environment. ][K[ Loading your code. ][K[ Loading the solution. ][K[ Preparing to launch the tests. ][K[ Launching the test bench. ][K.                              - Failure - 0 points

--- a/exercises/nondet_monad_seq/wrong/bind_once.ml
+++ b/exercises/nondet_monad_seq/wrong/bind_once.ml
@@ -1,0 +1,21 @@
+let return (x : 'a) : 'a m =
+  Seq.singleton x
+
+let (>>=) (m1 : 'a m) (f2 : 'a -> 'b m) : 'b m =
+  (* Not sure how to make a genuine mistake here,
+     but here is an attempt: *)
+  fun () ->
+    match m1() with
+    | Seq.Nil ->
+        Seq.Nil
+    | Seq.Cons (x1, _) -> (* wrong *)
+        f2 x1 ()
+
+let fail : 'a m =
+  Seq.nil
+
+let choose (m1 : 'a m) (m2 : 'a m) : 'a m =
+  Seq.concat m1 m2
+
+let sols (m : 'a m) : 'a Seq.t =
+  m

--- a/exercises/nondet_monad_seq/wrong/bind_once.report.txt
+++ b/exercises/nondet_monad_seq/wrong/bind_once.report.txt
@@ -1,0 +1,14 @@
+Question 1
+  Found [return] with compatible type.
+  Found [>>=] with compatible type.
+  Found [fail] with compatible type.
+  Found [choose] with compatible type.
+  Found [sols] with compatible type.
+  Functional correctness
+    Failure: Something is wrong. The following expression:
+      
+       | sols (choose (return 0) (return 0) >>= fun a -> return a)
+       | |> Seq.take 20
+       | |> Seq.to_list
+      produces the following result: [[0]] This is invalid. Producing the
+      following result is valid: [[0; 0]]

--- a/exercises/nondet_monad_seq/wrong/bind_take.log
+++ b/exercises/nondet_monad_seq/wrong/bind_take.log
@@ -1,0 +1,2 @@
+Learnocaml v.0.10 running.
+[ Loading the prelude. ][K[ Preparing the test environment. ][K[ Loading your code. ][K[ Loading the solution. ][K[ Preparing to launch the tests. ][K[ Launching the test bench. ][K.                              - Failure - 0 points

--- a/exercises/nondet_monad_seq/wrong/bind_take.ml
+++ b/exercises/nondet_monad_seq/wrong/bind_take.ml
@@ -1,0 +1,15 @@
+let return (x : 'a) : 'a m =
+  Seq.singleton x
+
+let (>>=) (m1 : 'a m) (f2 : 'a -> 'b m) : 'b m =
+  (* weird: take at most 2 results in each branch *)
+  m1 |> Seq.map f2 |> Seq.map (Seq.take 2) |> Seq.flatten
+
+let fail : 'a m =
+  Seq.nil
+
+let choose (m1 : 'a m) (m2 : 'a m) : 'a m =
+  Seq.concat m1 m2
+
+let sols (m : 'a m) : 'a Seq.t =
+  m

--- a/exercises/nondet_monad_seq/wrong/bind_take.report.txt
+++ b/exercises/nondet_monad_seq/wrong/bind_take.report.txt
@@ -1,0 +1,17 @@
+Question 1
+  Found [return] with compatible type.
+  Found [>>=] with compatible type.
+  Found [fail] with compatible type.
+  Found [choose] with compatible type.
+  Found [sols] with compatible type.
+  Functional correctness
+    Failure: Something is wrong. The following expression:
+      
+       | sols (
+       |   return 0 >>= fun a ->
+       |   choose (return a) (choose (return 0) (return 1))
+       | )
+       | |> Seq.take 20
+       | |> Seq.to_list
+      produces the following result: [[0; 0]] This is invalid. Producing the
+      following result is valid: [[0; 0; 1]]

--- a/exercises/nondet_monad_seq/wrong/choose_fail.log
+++ b/exercises/nondet_monad_seq/wrong/choose_fail.log
@@ -1,0 +1,2 @@
+Learnocaml v.0.10 running.
+[ Loading the prelude. ][K[ Preparing the test environment. ][K[ Loading your code. ][K[ Loading the solution. ][K[ Preparing to launch the tests. ][K[ Launching the test bench. ][K.                              - Failure - 0 points

--- a/exercises/nondet_monad_seq/wrong/choose_fail.ml
+++ b/exercises/nondet_monad_seq/wrong/choose_fail.ml
@@ -1,0 +1,14 @@
+let return (x : 'a) : 'a m =
+  Seq.singleton x
+
+let (>>=) (m1 : 'a m) (f2 : 'a -> 'b m) : 'b m =
+  m1 |> Seq.map f2 |> Seq.flatten
+
+let fail : 'a m =
+  Seq.nil
+
+let choose (m1 : 'a m) (m2 : 'a m) : 'a m =
+  fail (* wrong *)
+
+let sols (m : 'a m) : 'a Seq.t =
+  m

--- a/exercises/nondet_monad_seq/wrong/choose_fail.report.txt
+++ b/exercises/nondet_monad_seq/wrong/choose_fail.report.txt
@@ -1,0 +1,12 @@
+Question 1
+  Found [return] with compatible type.
+  Found [>>=] with compatible type.
+  Found [fail] with compatible type.
+  Found [choose] with compatible type.
+  Found [sols] with compatible type.
+  Functional correctness
+    Failure: Something is wrong. The following expression:
+      
+       | sols (choose (return 0) (return 0)) |> Seq.take 20 |> Seq.to_list
+      produces the following result: [[]] This is invalid. Producing the
+      following result is valid: [[0; 0]]

--- a/exercises/nondet_monad_seq/wrong/choose_left.log
+++ b/exercises/nondet_monad_seq/wrong/choose_left.log
@@ -1,0 +1,2 @@
+Learnocaml v.0.10 running.
+[ Loading the prelude. ][K[ Preparing the test environment. ][K[ Loading your code. ][K[ Loading the solution. ][K[ Preparing to launch the tests. ][K[ Launching the test bench. ][K.                              - Failure - 0 points

--- a/exercises/nondet_monad_seq/wrong/choose_left.ml
+++ b/exercises/nondet_monad_seq/wrong/choose_left.ml
@@ -1,0 +1,14 @@
+let return (x : 'a) : 'a m =
+  Seq.singleton x
+
+let (>>=) (m1 : 'a m) (f2 : 'a -> 'b m) : 'b m =
+  m1 |> Seq.map f2 |> Seq.flatten
+
+let fail : 'a m =
+  Seq.nil
+
+let choose (m1 : 'a m) (m2 : 'a m) : 'a m =
+  m1 (* wrong *)
+
+let sols (m : 'a m) : 'a Seq.t =
+  m

--- a/exercises/nondet_monad_seq/wrong/choose_left.report.txt
+++ b/exercises/nondet_monad_seq/wrong/choose_left.report.txt
@@ -1,0 +1,12 @@
+Question 1
+  Found [return] with compatible type.
+  Found [>>=] with compatible type.
+  Found [fail] with compatible type.
+  Found [choose] with compatible type.
+  Found [sols] with compatible type.
+  Functional correctness
+    Failure: Something is wrong. The following expression:
+      
+       | sols (choose (return 0) (return 0)) |> Seq.take 20 |> Seq.to_list
+      produces the following result: [[0]] This is invalid. Producing the
+      following result is valid: [[0; 0]]

--- a/exercises/nondet_monad_seq/wrong/choose_reversed.log
+++ b/exercises/nondet_monad_seq/wrong/choose_reversed.log
@@ -1,0 +1,2 @@
+Learnocaml v.0.10 running.
+[ Loading the prelude. ][K[ Preparing the test environment. ][K[ Loading your code. ][K[ Loading the solution. ][K[ Preparing to launch the tests. ][K[ Launching the test bench. ][K.                              - Failure - 0 points

--- a/exercises/nondet_monad_seq/wrong/choose_reversed.ml
+++ b/exercises/nondet_monad_seq/wrong/choose_reversed.ml
@@ -1,0 +1,14 @@
+let return (x : 'a) : 'a m =
+  Seq.singleton x
+
+let (>>=) (m1 : 'a m) (f2 : 'a -> 'b m) : 'b m =
+  m1 |> Seq.map f2 |> Seq.flatten
+
+let fail : 'a m =
+  Seq.nil
+
+let choose (m1 : 'a m) (m2 : 'a m) : 'a m =
+  Seq.concat m2 m1 (* wrong *)
+
+let sols (m : 'a m) : 'a Seq.t =
+  m

--- a/exercises/nondet_monad_seq/wrong/choose_reversed.report.txt
+++ b/exercises/nondet_monad_seq/wrong/choose_reversed.report.txt
@@ -1,0 +1,12 @@
+Question 1
+  Found [return] with compatible type.
+  Found [>>=] with compatible type.
+  Found [fail] with compatible type.
+  Found [choose] with compatible type.
+  Found [sols] with compatible type.
+  Functional correctness
+    Failure: Something is wrong. The following expression:
+      
+       | sols (choose (return 0) (return 1)) |> Seq.take 20 |> Seq.to_list
+      produces the following result: [[1; 0]] This is invalid. Producing the
+      following result is valid: [[0; 1]]

--- a/exercises/nondet_monad_seq/wrong/choose_right.log
+++ b/exercises/nondet_monad_seq/wrong/choose_right.log
@@ -1,0 +1,2 @@
+Learnocaml v.0.10 running.
+[ Loading the prelude. ][K[ Preparing the test environment. ][K[ Loading your code. ][K[ Loading the solution. ][K[ Preparing to launch the tests. ][K[ Launching the test bench. ][K.                              - Failure - 0 points

--- a/exercises/nondet_monad_seq/wrong/choose_right.ml
+++ b/exercises/nondet_monad_seq/wrong/choose_right.ml
@@ -1,0 +1,14 @@
+let return (x : 'a) : 'a m =
+  Seq.singleton x
+
+let (>>=) (m1 : 'a m) (f2 : 'a -> 'b m) : 'b m =
+  m1 |> Seq.map f2 |> Seq.flatten
+
+let fail : 'a m =
+  Seq.nil
+
+let choose (m1 : 'a m) (m2 : 'a m) : 'a m =
+  m2 (* wrong *)
+
+let sols (m : 'a m) : 'a Seq.t =
+  m

--- a/exercises/nondet_monad_seq/wrong/choose_right.report.txt
+++ b/exercises/nondet_monad_seq/wrong/choose_right.report.txt
@@ -1,0 +1,12 @@
+Question 1
+  Found [return] with compatible type.
+  Found [>>=] with compatible type.
+  Found [fail] with compatible type.
+  Found [choose] with compatible type.
+  Found [sols] with compatible type.
+  Functional correctness
+    Failure: Something is wrong. The following expression:
+      
+       | sols (choose (return 0) (return 0)) |> Seq.take 20 |> Seq.to_list
+      produces the following result: [[0]] This is invalid. Producing the
+      following result is valid: [[0; 0]]

--- a/exercises/nondet_monad_seq/wrong/delayed_failure.log
+++ b/exercises/nondet_monad_seq/wrong/delayed_failure.log
@@ -1,0 +1,2 @@
+Learnocaml v.0.10 running.
+[ Loading the prelude. ][K[ Preparing the test environment. ][K[ Loading your code. ][K[ Loading the solution. ][K[ Preparing to launch the tests. ][K[ Launching the test bench. ][K.                              - Failure - 0 points

--- a/exercises/nondet_monad_seq/wrong/delayed_failure.ml
+++ b/exercises/nondet_monad_seq/wrong/delayed_failure.ml
@@ -1,0 +1,21 @@
+exception Gotcha
+
+let gotcha : 'a m =
+  delay (fun () -> raise Gotcha)
+  (* wrong: this fails when the sequence is forced --
+     even though it appears to succeed at construction time. *)
+
+let return (x : 'a) : 'a m =
+  gotcha
+
+let (>>=) (m1 : 'a m) (f2 : 'a -> 'b m) : 'b m =
+  gotcha
+
+let fail : 'a m =
+  gotcha
+
+let choose (m1 : 'a m) (m2 : 'a m) : 'a m =
+  gotcha
+
+let sols (m : 'a m) : 'a Seq.t =
+  m

--- a/exercises/nondet_monad_seq/wrong/delayed_failure.report.txt
+++ b/exercises/nondet_monad_seq/wrong/delayed_failure.report.txt
@@ -1,0 +1,12 @@
+Question 1
+  Found [return] with compatible type.
+  Found [>>=] with compatible type.
+  Found [fail] with compatible type.
+  Found [choose] with compatible type.
+  Found [sols] with compatible type.
+  Functional correctness
+    Failure: Something is wrong. The following expression:
+      
+       | sols (return 0) |> Seq.take 20 |> Seq.to_list
+      raises the following exception: [Code.Gotcha] This is invalid.
+      Producing the following result is valid: [[0]]

--- a/exercises/nondet_monad_seq/wrong/early_at_most_once.log
+++ b/exercises/nondet_monad_seq/wrong/early_at_most_once.log
@@ -1,0 +1,2 @@
+Learnocaml v.0.10 running.
+[ Loading the prelude. ][K[ Preparing the test environment. ][K[ Loading your code. ][K[ Loading the solution. ][K[ Preparing to launch the tests. ][K[ Launching the test bench. ][K.                              - Failure - 3 points

--- a/exercises/nondet_monad_seq/wrong/early_at_most_once.ml
+++ b/exercises/nondet_monad_seq/wrong/early_at_most_once.ml
@@ -1,0 +1,22 @@
+let return (x : 'a) : 'a m =
+  Seq.singleton x
+
+let (>>=) (m1 : 'a m) (f2 : 'a -> 'b m) : 'b m =
+  m1 |> Seq.map f2 |> Seq.flatten
+
+let fail : 'a m =
+  Seq.nil
+
+let choose (m1 : 'a m) (m2 : 'a m) : 'a m =
+  Seq.concat m1 m2
+
+let sols (m : 'a m) : 'a Seq.t =
+  m
+
+let at_most_once (m : 'a m) : 'a m =
+  (* wrong: functionally correct, but too eager *)
+  match m() with
+  | Seq.Nil ->
+      fail
+  | Seq.Cons (x, _) ->
+      return x

--- a/exercises/nondet_monad_seq/wrong/early_at_most_once.report.txt
+++ b/exercises/nondet_monad_seq/wrong/early_at_most_once.report.txt
@@ -1,0 +1,32 @@
+Question 1
+  Found [return] with compatible type.
+  Found [>>=] with compatible type.
+  Found [fail] with compatible type.
+  Found [choose] with compatible type.
+  Found [sols] with compatible type.
+  Functional correctness
+    Success 1: The code seems correct. Tested 2411 scenarios.
+  Laziness
+    Success 1: The code seems lazy.
+Question 2
+  Found [return] with compatible type.
+  Found [>>=] with compatible type.
+  Found [fail] with compatible type.
+  Found [choose] with compatible type.
+  Found [sols] with compatible type.
+  Found [at_most_once] with compatible type.
+  Functional correctness
+    Success 1: The code seems correct. Tested 2486 scenarios.
+  Laziness
+    Failure: Some computations take place too early. The following
+             expression:
+      
+       | Seq.map snapshot sols (
+       |   choose (tick (return 0)) (at_most_once (tick (return 0)))
+       | )
+       | |> Seq.take 20
+       | |> Seq.to_list
+      produces the following result: [[((* value: *) 0, (* work: *) 2); ((*
+      value: *) 0, (* work: *) 2)]] This is invalid. Producing the following
+      result is valid: [[((* value: *) 0, (* work: *) 1); ((* value: *) 0, (*
+      work: *) 2)]]

--- a/exercises/nondet_monad_seq/wrong/early_bind.log
+++ b/exercises/nondet_monad_seq/wrong/early_bind.log
@@ -1,0 +1,2 @@
+Learnocaml v.0.10 running.
+[ Loading the prelude. ][K[ Preparing the test environment. ][K[ Loading your code. ][K[ Loading the solution. ][K[ Preparing to launch the tests. ][K[ Launching the test bench. ][K.                              - Failure - 1 points

--- a/exercises/nondet_monad_seq/wrong/early_bind.ml
+++ b/exercises/nondet_monad_seq/wrong/early_bind.ml
@@ -1,0 +1,17 @@
+let force (m : 'a m) : 'a m =
+  Seq.of_list (Seq.to_list m)
+
+let return (x : 'a) : 'a m =
+  Seq.singleton x
+
+let (>>=) (m1 : 'a m) (f2 : 'a -> 'b m) : 'b m =
+  force (m1 |> Seq.map f2 |> Seq.flatten)
+
+let fail : 'a m =
+  Seq.nil
+
+let choose (m1 : 'a m) (m2 : 'a m) : 'a m =
+  Seq.concat m1 m2
+
+let sols (m : 'a m) : 'a Seq.t =
+  m

--- a/exercises/nondet_monad_seq/wrong/early_bind.report.txt
+++ b/exercises/nondet_monad_seq/wrong/early_bind.report.txt
@@ -1,0 +1,22 @@
+Question 1
+  Found [return] with compatible type.
+  Found [>>=] with compatible type.
+  Found [fail] with compatible type.
+  Found [choose] with compatible type.
+  Found [sols] with compatible type.
+  Functional correctness
+    Success 1: The code seems correct. Tested 2411 scenarios.
+  Laziness
+    Failure: Some computations take place too early. The following
+             expression:
+      
+       | Seq.map snapshot sols (
+       |   tick (return 0) >>= fun a ->
+       |   choose (tick (return a)) (tick (return a))
+       | )
+       | |> Seq.take 20
+       | |> Seq.to_list
+      produces the following result: [[((* value: *) 0, (* work: *) 3); ((*
+      value: *) 0, (* work: *) 3)]] This is invalid. Producing the following
+      result is valid: [[((* value: *) 0, (* work: *) 2); ((* value: *) 0, (*
+      work: *) 3)]]

--- a/exercises/nondet_monad_seq/wrong/early_choose.log
+++ b/exercises/nondet_monad_seq/wrong/early_choose.log
@@ -1,0 +1,2 @@
+Learnocaml v.0.10 running.
+[ Loading the prelude. ][K[ Preparing the test environment. ][K[ Loading your code. ][K[ Loading the solution. ][K[ Preparing to launch the tests. ][K[ Launching the test bench. ][K.                              - Failure - 1 points

--- a/exercises/nondet_monad_seq/wrong/early_choose.ml
+++ b/exercises/nondet_monad_seq/wrong/early_choose.ml
@@ -1,0 +1,16 @@
+let return (x : 'a) : 'a m =
+  Seq.singleton x
+
+let (>>=) (m1 : 'a m) (f2 : 'a -> 'b m) : 'b m =
+  m1 |> Seq.map f2 |> Seq.flatten
+
+let fail : 'a m =
+  Seq.nil
+
+let choose (m1 : 'a m) (m2 : 'a m) : 'a m =
+  (* wrong in a weird way: force [m1] for no good reason *)
+  let _ = Seq.head m1 in
+  Seq.concat m1 m2
+
+let sols (m : 'a m) : 'a Seq.t =
+  m

--- a/exercises/nondet_monad_seq/wrong/early_choose.report.txt
+++ b/exercises/nondet_monad_seq/wrong/early_choose.report.txt
@@ -1,0 +1,19 @@
+Question 1
+  Found [return] with compatible type.
+  Found [>>=] with compatible type.
+  Found [fail] with compatible type.
+  Found [choose] with compatible type.
+  Found [sols] with compatible type.
+  Functional correctness
+    Success 1: The code seems correct. Tested 2411 scenarios.
+  Laziness
+    Failure: Some computations take place too early. The following
+             expression:
+      
+       | Seq.map snapshot sols (choose (tick (return 0)) (tick (return 0)))
+       | |> Seq.take 20
+       | |> Seq.to_list
+      produces the following result: [[((* value: *) 0, (* work: *) 2); ((*
+      value: *) 0, (* work: *) 3)]] This is invalid. Producing the following
+      result is valid: [[((* value: *) 0, (* work: *) 1); ((* value: *) 0, (*
+      work: *) 2)]]

--- a/exercises/nondet_monad_seq/wrong/early_choose_right.log
+++ b/exercises/nondet_monad_seq/wrong/early_choose_right.log
@@ -1,0 +1,2 @@
+Learnocaml v.0.10 running.
+[ Loading the prelude. ][K[ Preparing the test environment. ][K[ Loading your code. ][K[ Loading the solution. ][K[ Preparing to launch the tests. ][K[ Launching the test bench. ][K.                              - Failure - 1 points

--- a/exercises/nondet_monad_seq/wrong/early_choose_right.ml
+++ b/exercises/nondet_monad_seq/wrong/early_choose_right.ml
@@ -1,0 +1,16 @@
+let return (x : 'a) : 'a m =
+  Seq.singleton x
+
+let (>>=) (m1 : 'a m) (f2 : 'a -> 'b m) : 'b m =
+  m1 |> Seq.map f2 |> Seq.flatten
+
+let fail : 'a m =
+  Seq.nil
+
+let choose (m1 : 'a m) (m2 : 'a m) : 'a m =
+  (* wrong in a weird way: force [m2] for no good reason *)
+  let _ = Seq.head m2 in
+  Seq.concat m1 m2
+
+let sols (m : 'a m) : 'a Seq.t =
+  m

--- a/exercises/nondet_monad_seq/wrong/early_choose_right.report.txt
+++ b/exercises/nondet_monad_seq/wrong/early_choose_right.report.txt
@@ -1,0 +1,19 @@
+Question 1
+  Found [return] with compatible type.
+  Found [>>=] with compatible type.
+  Found [fail] with compatible type.
+  Found [choose] with compatible type.
+  Found [sols] with compatible type.
+  Functional correctness
+    Success 1: The code seems correct. Tested 2411 scenarios.
+  Laziness
+    Failure: Some computations take place too early. The following
+             expression:
+      
+       | Seq.map snapshot sols (choose (tick (return 0)) (tick (return 0)))
+       | |> Seq.take 20
+       | |> Seq.to_list
+      produces the following result: [[((* value: *) 0, (* work: *) 2); ((*
+      value: *) 0, (* work: *) 3)]] This is invalid. Producing the following
+      result is valid: [[((* value: *) 0, (* work: *) 1); ((* value: *) 0, (*
+      work: *) 2)]]

--- a/exercises/nondet_monad_seq/wrong/early_fair_bind.log
+++ b/exercises/nondet_monad_seq/wrong/early_fair_bind.log
@@ -1,0 +1,2 @@
+Learnocaml v.0.10 running.
+[ Loading the prelude. ][K[ Preparing the test environment. ][K[ Loading your code. ][K[ Loading the solution. ][K[ Preparing to launch the tests. ][K[ Launching the test bench. ][K.                              - Failure - 7 points

--- a/exercises/nondet_monad_seq/wrong/early_fair_bind.ml
+++ b/exercises/nondet_monad_seq/wrong/early_fair_bind.ml
@@ -1,0 +1,34 @@
+let return (x : 'a) : 'a m =
+  Seq.singleton x
+
+let (>>=) (m1 : 'a m) (f2 : 'a -> 'b m) : 'b m =
+  m1 |> Seq.map f2 |> Seq.flatten
+
+let fail : 'a m =
+  Seq.nil
+
+let choose (m1 : 'a m) (m2 : 'a m) : 'a m =
+  Seq.concat m1 m2
+
+let sols (m : 'a m) : 'a Seq.t =
+  m
+
+let at_most_once (m : 'a m) : 'a m =
+  Seq.take 1 m
+
+let rec interleave (m1 : 'a m) (m2 : 'a m) : 'a m =
+  delay (fun () ->
+    match m1() with
+    | Seq.Nil ->
+        m2
+    | Seq.Cons (x1, m1) ->
+        Seq.cons x1 (interleave m2 m1)
+  )
+
+let rec (>>-) (m1 : 'a m) (f2 : 'a -> 'b m) : 'b m =
+  (* wrong: missing [delay] *)
+    match m1() with
+    | Seq.Nil ->
+        Seq.nil
+    | Seq.Cons (x1, m1) ->
+        interleave (f2 x1) (m1 >>- f2)

--- a/exercises/nondet_monad_seq/wrong/early_fair_bind.report.txt
+++ b/exercises/nondet_monad_seq/wrong/early_fair_bind.report.txt
@@ -1,0 +1,61 @@
+Question 1
+  Found [return] with compatible type.
+  Found [>>=] with compatible type.
+  Found [fail] with compatible type.
+  Found [choose] with compatible type.
+  Found [sols] with compatible type.
+  Functional correctness
+    Success 1: The code seems correct. Tested 2411 scenarios.
+  Laziness
+    Success 1: The code seems lazy.
+Question 2
+  Found [return] with compatible type.
+  Found [>>=] with compatible type.
+  Found [fail] with compatible type.
+  Found [choose] with compatible type.
+  Found [sols] with compatible type.
+  Found [at_most_once] with compatible type.
+  Functional correctness
+    Success 1: The code seems correct. Tested 2486 scenarios.
+  Laziness
+    Success 1: The code seems lazy.
+Question 3
+  Found [return] with compatible type.
+  Found [>>=] with compatible type.
+  Found [fail] with compatible type.
+  Found [choose] with compatible type.
+  Found [sols] with compatible type.
+  Found [at_most_once] with compatible type.
+  Found [interleave] with compatible type.
+  Functional correctness
+    Success 1: The code seems correct. Tested 2867 scenarios.
+  Laziness
+    Success 1: The code seems lazy.
+Question 4
+  Found [return] with compatible type.
+  Found [>>=] with compatible type.
+  Found [fail] with compatible type.
+  Found [choose] with compatible type.
+  Found [sols] with compatible type.
+  Found [at_most_once] with compatible type.
+  Found [interleave] with compatible type.
+  Found [>>-] with compatible type.
+  Functional correctness
+    Success 1: The code seems correct. Tested 10356 scenarios.
+  Laziness
+    Failure: Some computations take place too early. The following
+             expression:
+      
+       | Seq.map snapshot sols (
+       |   choose (
+       |     tick (return 0)
+       |   ) (
+       |     tick (return 0) >>- fun a -> tick (return 0)
+       |   )
+       | )
+       | |> Seq.take 20
+       | |> Seq.to_list
+      produces the following result: [[((* value: *) 0, (* work: *) 2); ((*
+      value: *) 0, (* work: *) 3)]] This is invalid. Producing the following
+      result is valid: [[((* value: *) 0, (* work: *) 1); ((* value: *) 0, (*
+      work: *) 3)]]

--- a/exercises/nondet_monad_seq/wrong/early_interleave.log
+++ b/exercises/nondet_monad_seq/wrong/early_interleave.log
@@ -1,0 +1,2 @@
+Learnocaml v.0.10 running.
+[ Loading the prelude. ][K[ Preparing the test environment. ][K[ Loading your code. ][K[ Loading the solution. ][K[ Preparing to launch the tests. ][K[ Launching the test bench. ][K.                              - Failure - 5 points

--- a/exercises/nondet_monad_seq/wrong/early_interleave.ml
+++ b/exercises/nondet_monad_seq/wrong/early_interleave.ml
@@ -1,0 +1,24 @@
+let return (x : 'a) : 'a m =
+  Seq.singleton x
+
+let (>>=) (m1 : 'a m) (f2 : 'a -> 'b m) : 'b m =
+  m1 |> Seq.map f2 |> Seq.flatten
+
+let fail : 'a m =
+  Seq.nil
+
+let choose (m1 : 'a m) (m2 : 'a m) : 'a m =
+  Seq.concat m1 m2
+
+let sols (m : 'a m) : 'a Seq.t =
+  m
+
+let at_most_once (m : 'a m) : 'a m =
+  Seq.take 1 m
+
+let rec interleave (m1 : 'a m) (m2 : 'a m) : 'a m =
+  match m1() with
+  | Seq.Nil ->
+      m2
+  | Seq.Cons (x1, m1) ->
+      Seq.cons x1 (interleave m2 m1)

--- a/exercises/nondet_monad_seq/wrong/early_interleave.report.txt
+++ b/exercises/nondet_monad_seq/wrong/early_interleave.report.txt
@@ -1,0 +1,42 @@
+Question 1
+  Found [return] with compatible type.
+  Found [>>=] with compatible type.
+  Found [fail] with compatible type.
+  Found [choose] with compatible type.
+  Found [sols] with compatible type.
+  Functional correctness
+    Success 1: The code seems correct. Tested 2411 scenarios.
+  Laziness
+    Success 1: The code seems lazy.
+Question 2
+  Found [return] with compatible type.
+  Found [>>=] with compatible type.
+  Found [fail] with compatible type.
+  Found [choose] with compatible type.
+  Found [sols] with compatible type.
+  Found [at_most_once] with compatible type.
+  Functional correctness
+    Success 1: The code seems correct. Tested 2486 scenarios.
+  Laziness
+    Success 1: The code seems lazy.
+Question 3
+  Found [return] with compatible type.
+  Found [>>=] with compatible type.
+  Found [fail] with compatible type.
+  Found [choose] with compatible type.
+  Found [sols] with compatible type.
+  Found [at_most_once] with compatible type.
+  Found [interleave] with compatible type.
+  Functional correctness
+    Success 1: The code seems correct. Tested 2867 scenarios.
+  Laziness
+    Failure: Some computations take place too early. The following
+             expression:
+      
+       | Seq.map snapshot sols (interleave (tick (return 0)) (tick (return 0)))
+       | |> Seq.take 20
+       | |> Seq.to_list
+      produces the following result: [[((* value: *) 0, (* work: *) 2); ((*
+      value: *) 0, (* work: *) 2)]] This is invalid. Producing the following
+      result is valid: [[((* value: *) 0, (* work: *) 1); ((* value: *) 0, (*
+      work: *) 2)]]

--- a/exercises/nondet_monad_seq/wrong/early_sols.log
+++ b/exercises/nondet_monad_seq/wrong/early_sols.log
@@ -1,0 +1,2 @@
+Learnocaml v.0.10 running.
+[ Loading the prelude. ][K[ Preparing the test environment. ][K[ Loading your code. ][K[ Loading the solution. ][K[ Preparing to launch the tests. ][K[ Launching the test bench. ][K.                              - Failure - 1 points

--- a/exercises/nondet_monad_seq/wrong/early_sols.ml
+++ b/exercises/nondet_monad_seq/wrong/early_sols.ml
@@ -1,0 +1,17 @@
+let force (m : 'a m) : 'a m =
+  Seq.of_list (Seq.to_list m)
+
+let return (x : 'a) : 'a m =
+  Seq.singleton x
+
+let (>>=) (m1 : 'a m) (f2 : 'a -> 'b m) : 'b m =
+  force (m1 |> Seq.map f2 |> Seq.flatten)
+
+let fail : 'a m =
+  Seq.nil
+
+let choose (m1 : 'a m) (m2 : 'a m) : 'a m =
+  Seq.concat m1 m2
+
+let sols (m : 'a m) : 'a Seq.t =
+  m

--- a/exercises/nondet_monad_seq/wrong/early_sols.report.txt
+++ b/exercises/nondet_monad_seq/wrong/early_sols.report.txt
@@ -1,0 +1,22 @@
+Question 1
+  Found [return] with compatible type.
+  Found [>>=] with compatible type.
+  Found [fail] with compatible type.
+  Found [choose] with compatible type.
+  Found [sols] with compatible type.
+  Functional correctness
+    Success 1: The code seems correct. Tested 2411 scenarios.
+  Laziness
+    Failure: Some computations take place too early. The following
+             expression:
+      
+       | Seq.map snapshot sols (
+       |   tick (return 0) >>= fun a ->
+       |   choose (tick (return a)) (tick (return a))
+       | )
+       | |> Seq.take 20
+       | |> Seq.to_list
+      produces the following result: [[((* value: *) 0, (* work: *) 3); ((*
+      value: *) 0, (* work: *) 3)]] This is invalid. Producing the following
+      result is valid: [[((* value: *) 0, (* work: *) 2); ((* value: *) 0, (*
+      work: *) 3)]]

--- a/exercises/nondet_monad_seq/wrong/fair_bind_choose.log
+++ b/exercises/nondet_monad_seq/wrong/fair_bind_choose.log
@@ -1,0 +1,2 @@
+Learnocaml v.0.10 running.
+[ Loading the prelude. ][K[ Preparing the test environment. ][K[ Loading your code. ][K[ Loading the solution. ][K[ Preparing to launch the tests. ][K[ Launching the test bench. ][K.                              - Failure - 6 points

--- a/exercises/nondet_monad_seq/wrong/fair_bind_choose.ml
+++ b/exercises/nondet_monad_seq/wrong/fair_bind_choose.ml
@@ -1,0 +1,36 @@
+let return (x : 'a) : 'a m =
+  Seq.singleton x
+
+let (>>=) (m1 : 'a m) (f2 : 'a -> 'b m) : 'b m =
+  m1 |> Seq.map f2 |> Seq.flatten
+
+let fail : 'a m =
+  Seq.nil
+
+let choose (m1 : 'a m) (m2 : 'a m) : 'a m =
+  Seq.concat m1 m2
+
+let sols (m : 'a m) : 'a Seq.t =
+  m
+
+let at_most_once (m : 'a m) : 'a m =
+  Seq.take 1 m
+
+let rec interleave (m1 : 'a m) (m2 : 'a m) : 'a m =
+  delay (fun () ->
+    match m1() with
+    | Seq.Nil ->
+        m2
+    | Seq.Cons (x1, m1) ->
+        Seq.cons x1 (interleave m2 m1)
+  )
+
+let rec (>>-) (m1 : 'a m) (f2 : 'a -> 'b m) : 'b m =
+  delay (fun () ->
+    match m1() with
+    | Seq.Nil ->
+        Seq.nil
+    | Seq.Cons (x1, m1) ->
+        (* wrong: use [choose] instead of [interleave] *)
+        choose (f2 x1) (m1 >>- f2)
+  )

--- a/exercises/nondet_monad_seq/wrong/fair_bind_choose.report.txt
+++ b/exercises/nondet_monad_seq/wrong/fair_bind_choose.report.txt
@@ -1,0 +1,53 @@
+Question 1
+  Found [return] with compatible type.
+  Found [>>=] with compatible type.
+  Found [fail] with compatible type.
+  Found [choose] with compatible type.
+  Found [sols] with compatible type.
+  Functional correctness
+    Success 1: The code seems correct. Tested 2411 scenarios.
+  Laziness
+    Success 1: The code seems lazy.
+Question 2
+  Found [return] with compatible type.
+  Found [>>=] with compatible type.
+  Found [fail] with compatible type.
+  Found [choose] with compatible type.
+  Found [sols] with compatible type.
+  Found [at_most_once] with compatible type.
+  Functional correctness
+    Success 1: The code seems correct. Tested 2486 scenarios.
+  Laziness
+    Success 1: The code seems lazy.
+Question 3
+  Found [return] with compatible type.
+  Found [>>=] with compatible type.
+  Found [fail] with compatible type.
+  Found [choose] with compatible type.
+  Found [sols] with compatible type.
+  Found [at_most_once] with compatible type.
+  Found [interleave] with compatible type.
+  Functional correctness
+    Success 1: The code seems correct. Tested 2867 scenarios.
+  Laziness
+    Success 1: The code seems lazy.
+Question 4
+  Found [return] with compatible type.
+  Found [>>=] with compatible type.
+  Found [fail] with compatible type.
+  Found [choose] with compatible type.
+  Found [sols] with compatible type.
+  Found [at_most_once] with compatible type.
+  Found [interleave] with compatible type.
+  Found [>>-] with compatible type.
+  Functional correctness
+    Failure: Something is wrong. The following expression:
+      
+       | sols (
+       |   interleave (return 0) (return 1) >>- fun a ->
+       |   choose (return 0) (return 1)
+       | )
+       | |> Seq.take 20
+       | |> Seq.to_list
+      produces the following result: [[0; 1; 0; 1]] This is invalid.
+      Producing the following result is valid: [[0; 0; 1; 1]]

--- a/exercises/nondet_monad_seq/wrong/fair_bind_self.log
+++ b/exercises/nondet_monad_seq/wrong/fair_bind_self.log
@@ -1,0 +1,2 @@
+Learnocaml v.0.10 running.
+[ Loading the prelude. ][K[ Preparing the test environment. ][K[ Loading your code. ][K[ Loading the solution. ][K[ Preparing to launch the tests. ][K[ Launching the test bench. ][K.                              - Failure - 6 points

--- a/exercises/nondet_monad_seq/wrong/fair_bind_self.ml
+++ b/exercises/nondet_monad_seq/wrong/fair_bind_self.ml
@@ -1,0 +1,36 @@
+let return (x : 'a) : 'a m =
+  Seq.singleton x
+
+let (>>=) (m1 : 'a m) (f2 : 'a -> 'b m) : 'b m =
+  m1 |> Seq.map f2 |> Seq.flatten
+
+let fail : 'a m =
+  Seq.nil
+
+let choose (m1 : 'a m) (m2 : 'a m) : 'a m =
+  Seq.concat m1 m2
+
+let sols (m : 'a m) : 'a Seq.t =
+  m
+
+let at_most_once (m : 'a m) : 'a m =
+  Seq.take 1 m
+
+let rec interleave (m1 : 'a m) (m2 : 'a m) : 'a m =
+  delay (fun () ->
+    match m1() with
+    | Seq.Nil ->
+        m2
+    | Seq.Cons (x1, m1) ->
+        Seq.cons x1 (interleave m2 m1)
+  )
+
+let (>>-) (m1 : 'a m) (f2 : 'a -> 'b m) : 'b m =
+  delay (fun () ->
+    match m1() with
+    | Seq.Nil ->
+        Seq.nil
+    | Seq.Cons (x1, m1) ->
+        (* wrong: use [>>=] instead of [>>-] *)
+        interleave (f2 x1) (m1 >>= f2)
+  )

--- a/exercises/nondet_monad_seq/wrong/fair_bind_self.report.txt
+++ b/exercises/nondet_monad_seq/wrong/fair_bind_self.report.txt
@@ -1,0 +1,53 @@
+Question 1
+  Found [return] with compatible type.
+  Found [>>=] with compatible type.
+  Found [fail] with compatible type.
+  Found [choose] with compatible type.
+  Found [sols] with compatible type.
+  Functional correctness
+    Success 1: The code seems correct. Tested 2411 scenarios.
+  Laziness
+    Success 1: The code seems lazy.
+Question 2
+  Found [return] with compatible type.
+  Found [>>=] with compatible type.
+  Found [fail] with compatible type.
+  Found [choose] with compatible type.
+  Found [sols] with compatible type.
+  Found [at_most_once] with compatible type.
+  Functional correctness
+    Success 1: The code seems correct. Tested 2486 scenarios.
+  Laziness
+    Success 1: The code seems lazy.
+Question 3
+  Found [return] with compatible type.
+  Found [>>=] with compatible type.
+  Found [fail] with compatible type.
+  Found [choose] with compatible type.
+  Found [sols] with compatible type.
+  Found [at_most_once] with compatible type.
+  Found [interleave] with compatible type.
+  Functional correctness
+    Success 1: The code seems correct. Tested 2867 scenarios.
+  Laziness
+    Success 1: The code seems lazy.
+Question 4
+  Found [return] with compatible type.
+  Found [>>=] with compatible type.
+  Found [fail] with compatible type.
+  Found [choose] with compatible type.
+  Found [sols] with compatible type.
+  Found [at_most_once] with compatible type.
+  Found [interleave] with compatible type.
+  Found [>>-] with compatible type.
+  Functional correctness
+    Failure: Something is wrong. The following expression:
+      
+       | sols (
+       |   choose (interleave (return 0) (return 0)) (return 0) >>- fun a ->
+       |   choose (return 1 >>= fun b -> return b) (return 0)
+       | )
+       | |> Seq.take 20
+       | |> Seq.to_list
+      produces the following result: [[1; 1; 0; 0; 1; 0]] This is invalid.
+      Producing the following result is valid: [[1; 1; 0; 1; 0; 0]]

--- a/exercises/nondet_monad_seq/wrong/interleave_choose.log
+++ b/exercises/nondet_monad_seq/wrong/interleave_choose.log
@@ -1,0 +1,2 @@
+Learnocaml v.0.10 running.
+[ Loading the prelude. ][K[ Preparing the test environment. ][K[ Loading your code. ][K[ Loading the solution. ][K[ Preparing to launch the tests. ][K[ Launching the test bench. ][K.                              - Failure - 4 points

--- a/exercises/nondet_monad_seq/wrong/interleave_choose.ml
+++ b/exercises/nondet_monad_seq/wrong/interleave_choose.ml
@@ -1,0 +1,20 @@
+let return (x : 'a) : 'a m =
+  Seq.singleton x
+
+let (>>=) (m1 : 'a m) (f2 : 'a -> 'b m) : 'b m =
+  m1 |> Seq.map f2 |> Seq.flatten
+
+let fail : 'a m =
+  Seq.nil
+
+let choose (m1 : 'a m) (m2 : 'a m) : 'a m =
+  Seq.concat m1 m2
+
+let sols (m : 'a m) : 'a Seq.t =
+  m
+
+let at_most_once (m : 'a m) : 'a m =
+  Seq.take 1 m
+
+let interleave =
+  choose (* basic attempt at cheating *)

--- a/exercises/nondet_monad_seq/wrong/interleave_choose.report.txt
+++ b/exercises/nondet_monad_seq/wrong/interleave_choose.report.txt
@@ -1,0 +1,37 @@
+Question 1
+  Found [return] with compatible type.
+  Found [>>=] with compatible type.
+  Found [fail] with compatible type.
+  Found [choose] with compatible type.
+  Found [sols] with compatible type.
+  Functional correctness
+    Success 1: The code seems correct. Tested 2411 scenarios.
+  Laziness
+    Success 1: The code seems lazy.
+Question 2
+  Found [return] with compatible type.
+  Found [>>=] with compatible type.
+  Found [fail] with compatible type.
+  Found [choose] with compatible type.
+  Found [sols] with compatible type.
+  Found [at_most_once] with compatible type.
+  Functional correctness
+    Success 1: The code seems correct. Tested 2486 scenarios.
+  Laziness
+    Success 1: The code seems lazy.
+Question 3
+  Found [return] with compatible type.
+  Found [>>=] with compatible type.
+  Found [fail] with compatible type.
+  Found [choose] with compatible type.
+  Found [sols] with compatible type.
+  Found [at_most_once] with compatible type.
+  Found [interleave] with compatible type.
+  Functional correctness
+    Failure: Something is wrong. The following expression:
+      
+       | sols (interleave (choose (return 0) (return 0)) (return 1))
+       | |> Seq.take 20
+       | |> Seq.to_list
+      produces the following result: [[0; 0; 1]] This is invalid. Producing
+      the following result is valid: [[0; 1; 0]]

--- a/exercises/nondet_monad_seq/wrong/interleave_flaw.log
+++ b/exercises/nondet_monad_seq/wrong/interleave_flaw.log
@@ -1,0 +1,2 @@
+Learnocaml v.0.10 running.
+[ Loading the prelude. ][K[ Preparing the test environment. ][K[ Loading your code. ][K[ Loading the solution. ][K[ Preparing to launch the tests. ][K[ Launching the test bench. ][K.                              - Failure - 4 points

--- a/exercises/nondet_monad_seq/wrong/interleave_flaw.ml
+++ b/exercises/nondet_monad_seq/wrong/interleave_flaw.ml
@@ -1,0 +1,26 @@
+let return (x : 'a) : 'a m =
+  Seq.singleton x
+
+let (>>=) (m1 : 'a m) (f2 : 'a -> 'b m) : 'b m =
+  m1 |> Seq.map f2 |> Seq.flatten
+
+let fail : 'a m =
+  Seq.nil
+
+let choose (m1 : 'a m) (m2 : 'a m) : 'a m =
+  Seq.concat m1 m2
+
+let sols (m : 'a m) : 'a Seq.t =
+  m
+
+let at_most_once (m : 'a m) : 'a m =
+  Seq.take 1 m
+
+let rec interleave (m1 : 'a m) (m2 : 'a m) : 'a m =
+  delay (fun () ->
+    match m1() with
+    | Seq.Nil ->
+        fail (* wrong: should be [m2] *)
+    | Seq.Cons (x1, m1) ->
+        Seq.cons x1 (interleave m2 m1)
+  )

--- a/exercises/nondet_monad_seq/wrong/interleave_flaw.report.txt
+++ b/exercises/nondet_monad_seq/wrong/interleave_flaw.report.txt
@@ -1,0 +1,35 @@
+Question 1
+  Found [return] with compatible type.
+  Found [>>=] with compatible type.
+  Found [fail] with compatible type.
+  Found [choose] with compatible type.
+  Found [sols] with compatible type.
+  Functional correctness
+    Success 1: The code seems correct. Tested 2411 scenarios.
+  Laziness
+    Success 1: The code seems lazy.
+Question 2
+  Found [return] with compatible type.
+  Found [>>=] with compatible type.
+  Found [fail] with compatible type.
+  Found [choose] with compatible type.
+  Found [sols] with compatible type.
+  Found [at_most_once] with compatible type.
+  Functional correctness
+    Success 1: The code seems correct. Tested 2486 scenarios.
+  Laziness
+    Success 1: The code seems lazy.
+Question 3
+  Found [return] with compatible type.
+  Found [>>=] with compatible type.
+  Found [fail] with compatible type.
+  Found [choose] with compatible type.
+  Found [sols] with compatible type.
+  Found [at_most_once] with compatible type.
+  Found [interleave] with compatible type.
+  Functional correctness
+    Failure: Something is wrong. The following expression:
+      
+       | sols (interleave fail (return 0)) |> Seq.take 20 |> Seq.to_list
+      produces the following result: [[]] This is invalid. Producing the
+      following result is valid: [[0]]

--- a/exercises/nondet_monad_seq/wrong/return_double.log
+++ b/exercises/nondet_monad_seq/wrong/return_double.log
@@ -1,0 +1,2 @@
+Learnocaml v.0.10 running.
+[ Loading the prelude. ][K[ Preparing the test environment. ][K[ Loading your code. ][K[ Loading the solution. ][K[ Preparing to launch the tests. ][K[ Launching the test bench. ][K.                              - Failure - 0 points

--- a/exercises/nondet_monad_seq/wrong/return_double.ml
+++ b/exercises/nondet_monad_seq/wrong/return_double.ml
@@ -1,0 +1,14 @@
+let return (x : 'a) : 'a m =
+  Seq.cons x (Seq.cons x Seq.nil) (* wrong *)
+
+let (>>=) (m1 : 'a m) (f2 : 'a -> 'b m) : 'b m =
+  m1 |> Seq.map f2 |> Seq.flatten
+
+let fail : 'a m =
+  Seq.nil
+
+let choose (m1 : 'a m) (m2 : 'a m) : 'a m =
+  Seq.concat m1 m2
+
+let sols (m : 'a m) : 'a Seq.t =
+  m

--- a/exercises/nondet_monad_seq/wrong/return_double.report.txt
+++ b/exercises/nondet_monad_seq/wrong/return_double.report.txt
@@ -1,0 +1,12 @@
+Question 1
+  Found [return] with compatible type.
+  Found [>>=] with compatible type.
+  Found [fail] with compatible type.
+  Found [choose] with compatible type.
+  Found [sols] with compatible type.
+  Functional correctness
+    Failure: Something is wrong. The following expression:
+      
+       | sols (return 0) |> Seq.take 20 |> Seq.to_list
+      produces the following result: [[0; 0]] This is invalid. Producing the
+      following result is valid: [[0]]

--- a/exercises/nondet_monad_seq/wrong/return_infinite.log
+++ b/exercises/nondet_monad_seq/wrong/return_infinite.log
@@ -1,0 +1,2 @@
+Learnocaml v.0.10 running.
+[ Loading the prelude. ][K[ Preparing the test environment. ][K[ Loading your code. ][K[ Loading the solution. ][K[ Preparing to launch the tests. ][K[ Launching the test bench. ][K.                              - Failure - 0 points

--- a/exercises/nondet_monad_seq/wrong/return_infinite.ml
+++ b/exercises/nondet_monad_seq/wrong/return_infinite.ml
@@ -1,0 +1,14 @@
+let rec return (x : 'a) : 'a m =
+  delay (fun () -> Seq.cons x (return x)) (* vicious *)
+
+let (>>=) (m1 : 'a m) (f2 : 'a -> 'b m) : 'b m =
+  m1 |> Seq.map f2 |> Seq.flatten
+
+let fail : 'a m =
+  Seq.nil
+
+let choose (m1 : 'a m) (m2 : 'a m) : 'a m =
+  Seq.concat m1 m2
+
+let sols (m : 'a m) : 'a Seq.t =
+  m

--- a/exercises/nondet_monad_seq/wrong/return_infinite.report.txt
+++ b/exercises/nondet_monad_seq/wrong/return_infinite.report.txt
@@ -1,0 +1,13 @@
+Question 1
+  Found [return] with compatible type.
+  Found [>>=] with compatible type.
+  Found [fail] with compatible type.
+  Found [choose] with compatible type.
+  Found [sols] with compatible type.
+  Functional correctness
+    Failure: Something is wrong. The following expression:
+      
+       | sols (return 0) |> Seq.take 20 |> Seq.to_list
+      produces the following result: [[0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0;
+      0; 0; 0; 0; 0; 0; 0]] This is invalid. Producing the following result
+      is valid: [[0]]

--- a/exercises/nondet_monad_seq/wrong/return_nothing.log
+++ b/exercises/nondet_monad_seq/wrong/return_nothing.log
@@ -1,0 +1,2 @@
+Learnocaml v.0.10 running.
+[ Loading the prelude. ][K[ Preparing the test environment. ][K[ Loading your code. ][K[ Loading the solution. ][K[ Preparing to launch the tests. ][K[ Launching the test bench. ][K.                              - Failure - 0 points

--- a/exercises/nondet_monad_seq/wrong/return_nothing.ml
+++ b/exercises/nondet_monad_seq/wrong/return_nothing.ml
@@ -1,0 +1,14 @@
+let return (x : 'a) : 'a m =
+  Seq.nil (* wrong *)
+
+let (>>=) (m1 : 'a m) (f2 : 'a -> 'b m) : 'b m =
+  m1 |> Seq.map f2 |> Seq.flatten
+
+let fail : 'a m =
+  Seq.nil
+
+let choose (m1 : 'a m) (m2 : 'a m) : 'a m =
+  Seq.concat m1 m2
+
+let sols (m : 'a m) : 'a Seq.t =
+  m

--- a/exercises/nondet_monad_seq/wrong/return_nothing.report.txt
+++ b/exercises/nondet_monad_seq/wrong/return_nothing.report.txt
@@ -1,0 +1,12 @@
+Question 1
+  Found [return] with compatible type.
+  Found [>>=] with compatible type.
+  Found [fail] with compatible type.
+  Found [choose] with compatible type.
+  Found [sols] with compatible type.
+  Functional correctness
+    Failure: Something is wrong. The following expression:
+      
+       | sols (return 0) |> Seq.take 20 |> Seq.to_list
+      produces the following result: [[]] This is invalid. Producing the
+      following result is valid: [[0]]

--- a/exercises/nondet_monad_seq/wrong/template.log
+++ b/exercises/nondet_monad_seq/wrong/template.log
@@ -1,0 +1,2 @@
+Learnocaml v.0.10 running.
+[ Loading the prelude. ][K[ Preparing the test environment. ][K[ Loading your code. ][K[ Loading the solution. ][K[ Preparing to launch the tests. ][K[ Launching the test bench. ][K.                              - Failure - 0 points

--- a/exercises/nondet_monad_seq/wrong/template.ml
+++ b/exercises/nondet_monad_seq/wrong/template.ml
@@ -1,0 +1,31 @@
+let return (x : 'a) : 'a m =
+  (* TO DO: Define this function. *)
+  raise TODO
+
+let (>>=) (m1 : 'a m) (m2 : 'a -> 'b m) : 'b m =
+  (* TO DO: Define this function. *)
+  raise TODO
+
+let fail : 'a m =
+  (* TO DO: Define this constant. (Delete the whole line.) *)
+  delay (fun () -> raise TODO)
+
+let choose (m1 : 'a m) (m2 : 'a m) : 'a m =
+  (* TO DO: Define this function. *)
+  raise TODO
+
+let sols (m : 'a m) : 'a Seq.t =
+  (* TO DO: Define this function. *)
+  raise TODO
+
+let at_most_once (m : 'a m) : 'a m =
+  (* TO DO: Define this function. *)
+  raise TODO
+
+let rec interleave (m1 : 'a m) (m2 : 'a m) : 'a m =
+  (* TO DO: Define this function. *)
+  raise TODO
+
+let rec (>>-) (m1 : 'a m) (m2 : 'a -> 'b m) : 'b m =
+  (* TO DO: Define this function. *)
+  raise TODO

--- a/exercises/nondet_monad_seq/wrong/template.report.txt
+++ b/exercises/nondet_monad_seq/wrong/template.report.txt
@@ -1,0 +1,8 @@
+Question 1
+  Found [return] with compatible type.
+  Found [>>=] with compatible type.
+  Found [fail] with compatible type.
+  Found [choose] with compatible type.
+  Found [sols] with compatible type.
+  Functional correctness
+    Failure: Not yet implemented.


### PR DESCRIPTION
These two exercises implement the same API (the nondeterminism monad) using two different techniques, namely sequences and continuations. The grading code is the same; it relies on black-box testing. It tests both functional correctness and laziness.

I am preparing a third exercise based on a defunctionalized-continuation implementation; essentially an abstract machine.

The grading code works in batch mode, but I have seen it fail in the browser with a `Stack_overflow` exception. I am opening an issue on this topic.