### PR TITLE
fix(persistent_arrays/prepare.ml): Avoid weak polymorphism

### DIFF
--- a/exercises/fpottier/persistent_arrays/prepare.ml
+++ b/exercises/fpottier/persistent_arrays/prepare.ml
@@ -4,11 +4,7 @@ exception TODO
    count how many times it is used. Cross our fingers and hope
    that the student does not use the notation [r.contents]. *)
 
-let (!), get_count =
-  let count = ref 0 in
-  let (!) r =
-    incr count; !r
-  and get_count() =
-    !count
-  in
-  (!), get_count
+let count = ref 0
+let get_count () = !count
+let (!) r = incr count; !r
+let count = 0 (* for shadowing purposes *)


### PR DESCRIPTION
MOTIVATION:

After https://github.com/ocaml-sf/learn-ocaml/pull/458,
we'll precompile {prelude,prepare}.ml in `*.cm*` files.

The previous implementation led to a compilation issue:

```
File "prepare.ml", line 7, characters 4-7:
7 | let (!), get_count =
        ^^^
Error: The type of this expression, '_weak1 ref -> '_weak1,
       contains type variables that cannot be generalized
```