### PR TITLE
Fix anagram test

### DIFF
--- a/exercises/mooc/week6/seq1/ex2/solution.ml
+++ b/exercises/mooc/week6/seq1/ex2/solution.ml
@@ -41,6 +41,8 @@ let letters word =
   !s
 
 let anagram word1 word2 =
-  let s = ref (letters word1) in
-  String.iter (fun c -> s := MultiSet.remove !s c) word2;
-  !s = MultiSet.empty
+  String.(length word1 = length word2) && begin
+    let s = ref (letters word1) in
+    String.iter (fun c -> s := MultiSet.remove !s c) word2;
+    !s = MultiSet.empty
+  end


### PR DESCRIPTION
Without a check on the lengths of the words, `anagram "" w` is `true` for any `w` (because the empty multiset remains empty after removing all letters from w).
Actually, the problem is even more general: `anagram w1 w2` is `true` whenever an anagram of `w1` can be constructed with letters from `w2`.