### PR TITLE
Small changes required for the upcoming "precompiled" version of learn-ocaml

### DIFF
--- a/exercises/fpottier/tictactoe/test.ml
+++ b/exercises/fpottier/tictactoe/test.ml
@@ -1270,7 +1270,7 @@ let rec bseqlength n xs =
 
 type path = int list
 
-exception Fail of path * string
+exception Failp of path * string
 
 exception Length of path * exn
 
@@ -1281,7 +1281,7 @@ let compare (reference : tree) (candidate : tree) : unit =
   Q.add (reference, candidate, []) q;
   while not (Q.is_empty q) do
     let t0, t1, path = Q.take q in
-    let fail msg = raise (Fail (List.rev path, msg)) in
+    let fail msg = raise (Failp (List.rev path, msg)) in
     match t0, t1 with
     | TLeaf _, TNonLeaf _ ->
         fail "A leaf is expected, yet a node is found."
@@ -1422,7 +1422,7 @@ let test_tree () =
             try
               compare expected_tree actual_tree
             with
-            | Fail (path, msg) ->
+            | Failp (path, msg) ->
                 fail (
                   something_is_wrong @
                   R.Text "The following expression produces an incorrect subtree:" ::

--- a/exercises/fpottier/unionfind/prepare.ml
+++ b/exercises/fpottier/unionfind/prepare.ml
@@ -33,7 +33,7 @@ end = struct
   let (!) r = incr c; !r
 end
 
-open R
+include R
 
 (* The following type definitions should ideally be public, but we cannot
    place them in prelude.ml because prepare depends on prelude, not the

--- a/exercises/index.json
+++ b/exercises/index.json
@@ -40,7 +40,9 @@
 		"mooc/week6/seq1/ex1",
 		"mooc/week6/seq1/ex2",
 		"mooc/week6/seq2/ex1",
-		"mooc/week6/seq3/ex1"
+		"mooc/week6/seq3/ex1",
+		"mooc/projects/klotski",
+		"mooc/projects/markov"
 	    ]
 	},
 

--- a/exercises/mooc/projects/klotski/prepare.ml
+++ b/exercises/mooc/projects/klotski/prepare.ml
@@ -13,7 +13,7 @@ let print_int_list_set ppf int_set =
        ~pp_sep: (fun ppf () -> Format.fprintf ppf ";")
        print_int_list)
     (IntListSet.elements int_set) ;;
-#install_printer print_int_list_set ;;
+(* #install_printer print_int_list_set ;; *)
 
 module IntSet = Set.Make (struct type t = int let compare = (-) end)
 type int_set_operations = (int, IntSet.t) set_operations
@@ -25,7 +25,7 @@ let print_int_set ppf int_set =
        ~pp_sep: (fun ppf () -> Format.fprintf ppf ";")
        (fun ppf -> Format.fprintf ppf "%d"))
     (IntSet.elements int_set) ;;
-#install_printer print_int_set ;;
+(* #install_printer print_int_set ;; *)
 
 module Anim = struct
   type point = float * float

--- a/exercises/mooc/projects/markov/test.ml
+++ b/exercises/mooc/projects/markov/test.ml
@@ -8,7 +8,7 @@ let print_long_string ppf str =
     Format.fprintf ppf "%S" str
 
 ;;
-#install_printer print_long_string
+(* #install_printer print_long_string *)
 ;;
 
 let print_htable ppf htable =
@@ -23,7 +23,7 @@ let print_htable ppf htable =
   Format.fprintf ppf  "table)@]"
 
 ;;
-#install_printer print_htable
+(* #install_printer print_htable *)
 ;;
 
 let print_ptable_table ppf table =
@@ -39,7 +39,7 @@ let print_ptable_table ppf table =
   Format.fprintf ppf  "table)@]"
 
 ;;
-#install_printer print_ptable_table
+(* #install_printer print_ptable_table *)
 ;;
 
 let print_ptable ppf { prefix_length ; table } =
@@ -55,7 +55,7 @@ let print_ptable ppf { prefix_length ; table } =
   Format.fprintf ppf  "{ prefix_length ; table })@]"
 
 ;;
-#install_printer print_ptable
+(* #install_printer print_ptable *)
 ;;
 
 let graded n cb =

--- a/exercises/mooc/week2/seq2/ex2/test.ml
+++ b/exercises/mooc/week2/seq2/ex2/test.ml
@@ -2,7 +2,7 @@ open Report
 open Test_lib
 
 let print_float ppf = Format.fprintf ppf "%.3f" ;;
-#install_printer print_float ;;
+(* #install_printer print_float ;; *)
 
 let dist p1 p2 =
   sqrt ((p1.x -. p2.x) ** 2. +. (p1.y -. p2.y) ** 2. +. (p1.z -. p2.z) ** 2.)

--- a/exercises/mooc/week3/seq4/ex1/test.ml
+++ b/exercises/mooc/week3/seq4/ex1/test.ml
@@ -1,7 +1,7 @@
 open Report
 open Test_lib
 
-let rec sample_bt ~balanced sample () =
+let rec gen_sample_bt ~balanced sample () =
   let rec rew = function
     | Empty -> Empty
     | Node (l, _, r) -> Node (rew l, sample (), rew r) in
@@ -11,14 +11,14 @@ let rec sample_bt ~balanced sample () =
       let s = sample_rec (level - 1) in Node (s, sample (), rew s)
     else Node (sample_rec (level - 1), sample (), sample_rec (level - 1)) in
   match sample_rec 6 with
-  | Empty -> sample_bt ~balanced sample ()
+  | Empty -> gen_sample_bt ~balanced sample ()
   | res when Solution.balanced res = balanced -> res
-  | _ -> sample_bt ~balanced sample ()
+  | _ -> gen_sample_bt ~balanced sample ()
 
 let sample_bt sample =
   sample_alternatively
-    [ (fun () -> sample_bt ~balanced: true sample ()) ;
-      (fun () -> sample_bt ~balanced: false sample ()) ]
+    [ (fun () -> gen_sample_bt ~balanced: true sample ()) ;
+      (fun () -> gen_sample_bt ~balanced: false sample ()) ]
 
 let exercise_1 =
   set_progress "Grading exercise 1." ;

--- a/exercises/mooc/week4/seq3/ex1/prepare.ml
+++ b/exercises/mooc/week4/seq3/ex1/prepare.ml
@@ -26,7 +26,7 @@ module Pervasives = struct
     div_f x y
 end
 
-open Pervasives
+include Pervasives
 
 let test_ccr ccr (a, b, c, s) =
   let unset_all () =

--- a/exercises/mooc/week5/seq1/ex1/test.ml
+++ b/exercises/mooc/week5/seq1/ex1/test.ml
@@ -1,7 +1,7 @@
 open Report
 open Test_lib
 
-let rec sample_bt ~balanced sample () =
+let rec gen_sample_bt ~balanced sample () =
   let rec rew = function
     | Empty -> Empty
     | Node (l, _, r) -> Node (rew l, sample (), rew r) in
@@ -11,14 +11,14 @@ let rec sample_bt ~balanced sample () =
       let s = sample_rec (level - 1) in Node (s, sample (), rew s)
     else Node (sample_rec (level - 1), sample (), sample_rec (level - 1)) in
   match sample_rec 6 with
-  | Empty -> sample_bt ~balanced sample ()
+  | Empty -> gen_sample_bt ~balanced sample ()
   | res when fst (Solution.balanced res) = balanced -> res
-  | _ -> sample_bt ~balanced sample ()
+  | _ -> gen_sample_bt ~balanced sample ()
 
 let sample_bt sample =
   sample_alternatively
-    [ (fun () -> sample_bt ~balanced: true sample ()) ;
-      (fun () -> sample_bt ~balanced: false sample ()) ]
+    [ (fun () -> gen_sample_bt ~balanced: true sample ()) ;
+      (fun () -> gen_sample_bt ~balanced: false sample ()) ]
 
 let exercise_1_height =
   set_progress "Grading exercise 1." ;

--- a/exercises/mooc/week5/seq2/ex1/test.ml
+++ b/exercises/mooc/week5/seq2/ex1/test.ml
@@ -1,6 +1,8 @@
 open Report
 open Test_lib
 
+let sample_int = sample_int
+
 let exercise_1 =
   Section ([ Text "Exercise 1: " ; Code "print_int_list" ],
            test_function_1_against_solution


### PR DESCRIPTION
Some quirks needed in porting to the pre-compiling version of learn-ocaml:

- remove `#install_printer` (and any other) directives: we are no longer in a toplevel so these are no longer available. However, using tricky hacks, you can still define a printer for type `foo` with just `let print_<foo> ppf x = ... Format.fprintf ppf ...`

- replacing `open` intended for shadowing with `include` in Prepare/Prelude
  (fpottier/unionfind/prepare.ml, mooc/week4/seq3/ex1/prepare.ml)
  Open can't reach outside of its compilation unit

- renamed multiple definitions of exceptions/types/modules with the same name
  (fpottier/tictactoe/test.ml)
  this is allowed in the toplevel but not by the OCaml compiler

- renamed toplevel functions named `sample_*` that don't type as samplers
  (mooc/week3/seq4/ex1/test.ml, mooc/week5/seq1/ex1/test.ml)
  These are dynamically typed later on, which just issues a warning, so we could
  disable this less precise check altogether for better compat, but it seems
  cleaner to reject them

- avoid using a default sampler then overriding it
  (mooc/week5/seq2/ex1/test.ml)
  Due to difficulties in name resolution, this is forbidden, but the workaround
  is simple: just alias the built-in sampler locally before the first use.